### PR TITLE
Add attributes for accessible modal

### DIFF
--- a/examples/react-template/screens/Modal.tsx
+++ b/examples/react-template/screens/Modal.tsx
@@ -1,10 +1,8 @@
-import React from "react";
 import {
   Divider,
   IconName,
   Modal,
   ModalFooter,
-  ModalMarkup,
   ModalTitle,
   Section,
   Text,
@@ -14,8 +12,8 @@ import {
   TimelineMarker,
   Title,
   TitleLevels,
-} from "@trilogy-ds/react/components";
-import {Button, ButtonVariant} from "@trilogy-ds/react";
+} from '@trilogy-ds/react'
+import React from 'react'
 
 export const ModalScreen = (): JSX.Element => {
   return (
@@ -25,85 +23,62 @@ export const ModalScreen = (): JSX.Element => {
         <Divider />
 
         <Modal
-          active
           panel
-          triggerMarkup={ModalMarkup.A}
-          title={"Modal panel Title"}
-          ctaContent={"Action"}
-          ctaOnClick={() => alert("Click on cta")}
+          title={'Modal panel Title'}
+          ctaContent={'Action'}
+          ctaOnClick={() => alert('Click on cta')}
           closeIcon
-          ctaCancelOnClick={() => alert("cancel action")}
+          ctaCancelOnClick={() => alert('cancel action')}
         >
           <Timeline>
             <TimelineItem done>
               <TimelineMarker iconName={IconName.CHECK} />
-              <TimelineContent heading="08 July" content="Step 1" />
+              <TimelineContent heading='08 July' content='Step 1' />
             </TimelineItem>
             <TimelineItem active>
               <TimelineMarker iconName={IconName.CHECK} />
-              <TimelineContent
-                heading="09 July"
-                content="Step 2"
-                link="link"
-                contentLink="Go to link"
-              />
+              <TimelineContent heading='09 July' content='Step 2' link='link' contentLink='Go to link' />
             </TimelineItem>
             <TimelineItem undone>
               <TimelineMarker iconName={IconName.CHECK} />
-              <TimelineContent
-                heading="10 July"
-                content="Step 3"
-                link="link"
-                contentLink="Go to your profile"
-              />
+              <TimelineContent heading='10 July' content='Step 3' link='link' contentLink='Go to your profile' />
             </TimelineItem>
           </Timeline>
           <Text>
-            Contrary to popular belief, Lorem Ipsum is not simply random text.
-            It has roots in a piece of classical Latin literature from 45 BC,
-            making it over 2000 years old. Richard McClintock, a Latin professor
-            at Hampden-Sydney College in Virginia, looked up one of the more
-            obscure Latin words, consectetur, from a Lorem Ipsum passage, and
-            going through the cites of the word in classical literature,
-            discovered the undoubtable source. Lorem Ipsum comes from sections
-            1.10.32 and 1.10.33 of de Finibus Bonorum et Malorum (The Extremes
-            of Good and Evil) by Cicero, written in 45 BC. This book is a
-            treatise on the theory of ethics, very popular during the
-            Renaissance. The first line of Lorem Ipsum, Lorem ipsum dolor sit
-            amet.. , comes from a line in section 1.10.32. The standard chunk of
-            Lorem Ipsum used since the 1500s is reproduced below for those
-            interested. Sections 1.10.32 and 1.10.33 from de Finibus Bonorum et
-            Malorum by Cicero are also reproduced in their exact original form,
-            accompanied by English versions from the 1914 translation by H.
-            Rackham.Contrary to popular belief, Lorem Ipsum is not simply random
-            text. It has roots in a piece of classical Latin literature from 45
-            BC, making it over 2000 years old. Richard McClintock, a Latin
-            professor at Hampden-Sydney College in Virginia, looked up one of
-            the more obscure Latin words, consectetur, from a Lorem Ipsum
-            passage, and going through the cites of the word in classical
-            literature, discovered the undo
+            Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical
+            Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at
+            Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem
+            Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable
+            source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of de Finibus Bonorum et Malorum (The Extremes
+            of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular
+            during the Renaissance. The first line of Lorem Ipsum, Lorem ipsum dolor sit amet.. , comes from a line in
+            section 1.10.32. The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those
+            interested. Sections 1.10.32 and 1.10.33 from de Finibus Bonorum et Malorum by Cicero are also reproduced in
+            their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.Contrary
+            to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin
+            literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at
+            Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem
+            Ipsum passage, and going through the cites of the word in classical literature, discovered the undo
           </Text>
         </Modal>
 
         <Modal
           content={
             'Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.\n' +
-            "\n" +
+            '\n' +
             'The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.\n' +
-            "\n" +
+            '\n' +
             'The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.\n' +
-            "\n" +
+            '\n' +
             'The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.'
           }
-          triggerMarkup={ModalMarkup.BUTTON}
-          title="title modal"
-          triggerContent="Open accessible modal"
-          ctaContent="Action"
-          ctaCancelOnClick={() => alert("cancel action")}
+          title='title modal'
+          triggerContent='Open accessible modal'
+          ctaContent='Action'
           // eslint-disable-next-line no-alert
-          ctaOnClick={() => alert("Click on cta")}
-          onOpen={() => alert("open modal")}
-          onClose={() => alert("close modal")}
+          ctaOnClick={() => alert('Click on cta')}
+          onOpen={() => alert('open modal')}
+          onClose={() => alert('close modal')}
           iconName={IconName.BELL}
           closeIcon
           // ctaCancelOnClick={() => alert('toto')}
@@ -114,53 +89,43 @@ export const ModalScreen = (): JSX.Element => {
         <Divider />
 
         <Modal
-          triggerMarkup={ModalMarkup.A}
-          triggerContent="Open modal"
-          onOpen={() => alert("open modal")}
-          onClose={() => alert("close modal")}
+          triggerContent='Open modal'
+          onOpen={() => alert('open modal')}
+          onClose={() => alert('close modal')}
           closeIcon
         >
           <ModalTitle>Custom title</ModalTitle>
           <Text
             htmlContent={
               'Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.\n' +
-              "\n" +
+              '\n' +
               'The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.\n' +
-              "\n" +
+              '\n' +
               'The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.\n' +
-              "\n" +
+              '\n' +
               'The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.'
             }
           />
-          <ModalFooter><Button variant={ButtonVariant.PRIMARY} > Click Me ! </Button></ModalFooter>
+          <ModalFooter>Custom Footer</ModalFooter>
         </Modal>
       </Section>
       <Section>
         <Title level={TitleLevels.THREE}>Modal click outside </Title>
         <Divider />
 
-        <Modal
-          triggerMarkup={ModalMarkup.A}
-          triggerContent="Open modal"
-          iconName="tri-check-circle"
-          iconColor="SUCCESS"
-          closeIcon
-        >
+        <Modal triggerContent='Open modal' iconName='tri-check-circle' iconColor='SUCCESS' closeIcon>
           <ModalTitle>Titre 2</ModalTitle>
           <Text>icon modal content</Text>
         </Modal>
       </Section>
       <Section>
-        <Title level={TitleLevels.THREE}>
-          Modal with disable click outside{" "}
-        </Title>
+        <Title level={TitleLevels.THREE}>Modal with disable click outside </Title>
         <Divider />
 
         <Modal
-          triggerMarkup={ModalMarkup.A}
-          triggerContent="Open modal"
-          iconName="tri-check-circle"
-          iconColor="SUCCESS"
+          triggerContent='Open modal'
+          iconName='tri-check-circle'
+          iconColor='SUCCESS'
           disableHandlingClickOutside
           closeIcon
         >
@@ -169,5 +134,5 @@ export const ModalScreen = (): JSX.Element => {
         </Modal>
       </Section>
     </>
-  );
-};
+  )
+}

--- a/examples/react-template/screens/Modal.tsx
+++ b/examples/react-template/screens/Modal.tsx
@@ -95,9 +95,9 @@ export const ModalScreen = (): JSX.Element => {
             "\n" +
             'The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.'
           }
-          triggerMarkup={ModalMarkup.A}
+          triggerMarkup={ModalMarkup.BUTTON}
           title="title modal"
-          triggerContent="Open modal"
+          triggerContent="Open accessible modal"
           ctaContent="Action"
           ctaCancelOnClick={() => alert("cancel action")}
           // eslint-disable-next-line no-alert

--- a/examples/react-template/screens/Modal.tsx
+++ b/examples/react-template/screens/Modal.tsx
@@ -85,6 +85,8 @@ export const ModalScreen = (): JSX.Element => {
           titleButtonClose='Fermer'
           ariaLabelButtonClose='Fermer'
           ariaLabelCta='action'
+          ariaLabelButtonOpen='Ouvrir'
+          titleButtonOpen='Ouvrir'
         />
       </Section>
       <Section>

--- a/examples/react-template/screens/Modal.tsx
+++ b/examples/react-template/screens/Modal.tsx
@@ -81,7 +81,10 @@ export const ModalScreen = (): JSX.Element => {
           onClose={() => alert('close modal')}
           iconName={IconName.BELL}
           closeIcon
-          // ctaCancelOnClick={() => alert('toto')}
+          ctaCancelOnClick={() => alert('toto')}
+          titleButtonClose='Fermer'
+          ariaLabelButtonClose='Fermer'
+          ariaLabelCta='action'
         />
       </Section>
       <Section>

--- a/packages/react/components/icon/text/TextIcon.tsx
+++ b/packages/react/components/icon/text/TextIcon.tsx
@@ -11,6 +11,10 @@ import clsx from "clsx"
 import { hashClass } from "@/helpers"
 import { useTrilogyContext } from "@/context"
 
+ interface Props extends IconProps {
+  textId?:string
+}
+
 const TextIcon = ({
   className,
   textClassName,
@@ -18,8 +22,9 @@ const TextIcon = ({
   content,
   position,
   markup,
+  textId,
   ...others
-}: IconProps): JSX.Element => {
+}: Props): JSX.Element => {
   const { styled } = useTrilogyContext()
 
   const isCorrectMarkup = (
@@ -50,7 +55,7 @@ const TextIcon = ({
           (position === IconPosition.RIGHT || position === IconPosition.DOWN) &&
             content &&
             (content && typeof content.valueOf() === "string" ? (
-              <Tag className={hashClass(styled, clsx(textClassName))}>
+              <Tag className={hashClass(styled, clsx(textClassName))} id={textId}>
                 {String(content)}
               </Tag>
             ) : (
@@ -63,7 +68,7 @@ const TextIcon = ({
           (position === IconPosition.UP || position === IconPosition.LEFT) &&
             content &&
             (content && typeof content.valueOf() === "string" ? (
-              <Tag className={hashClass(styled, clsx(textClassName))}>
+              <Tag className={hashClass(styled, clsx(textClassName))} id={textId}>
                 {String(content)}
               </Tag>
             ) : (
@@ -79,7 +84,7 @@ const TextIcon = ({
     <span className={hashClass(styled, clsx("icon-and-text", className))}>
       <Icon name={name} {...others} />
       {content && typeof content.valueOf() === "string" ? (
-        <Tag className={hashClass(styled, clsx(textClassName))}>
+        <Tag className={hashClass(styled, clsx(textClassName))} id={textId}>
           {String(content)}
         </Tag>
       ) : (

--- a/packages/react/components/modal/Modal.tsx
+++ b/packages/react/components/modal/Modal.tsx
@@ -73,6 +73,8 @@ const Modal = ({
   ariaLabelButtonClose,
   ariaLabelCta,
   titleButtonClose,
+  ariaLabelButtonOpen,
+  titleButtonOpen,
   ...others
 }: ModalProps): JSX.Element => {
   const modal = useRef<HTMLDivElement>(null)
@@ -174,6 +176,8 @@ const Modal = ({
     <div data-testid={testId} onKeyDown={onKeyDown}>
       {triggerContent && (
         <TriggerTag
+          aria-label={ariaLabelButtonOpen}
+          title={titleButtonOpen}
           ref={refBtnModal}
           aria-controls={ariaControls}
           onClick={(e: React.MouseEvent) => {

--- a/packages/react/components/modal/Modal.tsx
+++ b/packages/react/components/modal/Modal.tsx
@@ -39,6 +39,9 @@ const idModal = shortid.generate()
  * @param triggerMarkup {ModalMarkup} h1|h2|h3|h4|h5|h6|p|span|div|button|a
  * @param triggerClassNames {string} Additionnal CSS Classes for trigger element
  * @param panel {boolean} Panel Side Modal
+ * @param ariaLabelButtonClose {string} aria-label of button close
+ * @param ariaLabelCta {string} aria-label of button action
+ * @param titleButtonClose {string} title of button close
  * - -------------------------- NATIVE PROPERTIES -------------------------------
  * @param bottom {boolean} If bottom
  * @param swipable {boolean} Swipable Native Modal
@@ -67,6 +70,9 @@ const Modal = ({
   fullwidth,
   disableHandlingClickOutside = false,
   testId,
+  ariaLabelButtonClose,
+  ariaLabelCta,
+  titleButtonClose,
   ...others
 }: ModalProps): JSX.Element => {
   const modal = useRef<HTMLDivElement>(null)
@@ -193,9 +199,9 @@ const Modal = ({
                 handleClose(onClose, e)
               }}
               className={hashClass(styled, clsx('modal-close', is('large')))}
-              aria-label='Fermer la modal'
+              aria-label={ariaLabelButtonClose}
               type={ButtonType.BUTTON}
-              title='Fermer la modal'
+              title={titleButtonClose}
               aria-controls={ariaControls}
               ref={(el) => el && (refsActions.current[0] = el)}
             />
@@ -216,8 +222,8 @@ const Modal = ({
                       handleClose(ctaCancelOnClick, e)
                     }}
                     className={hashClass(styled, clsx('button', is('secondary')))}
-                    aria-label='Fermer la modal'
-                    title='Fermer la modal'
+                    aria-label={ariaLabelButtonClose}
+                    title={titleButtonClose}
                     aria-controls={ariaControls}
                     ref={(el) => (refsActions.current[1] = el)}
                   >
@@ -227,7 +233,7 @@ const Modal = ({
                 {ctaOnClick && (
                   <button
                     className={hashClass(styled, clsx('button', is('primary')))}
-                    aria-label={ctaContent}
+                    aria-label={ariaLabelCta}
                     title={ctaContent}
                     aria-controls={ariaControls}
                     ref={(el) => (refsActions.current[2] = el)}

--- a/packages/react/components/modal/Modal.tsx
+++ b/packages/react/components/modal/Modal.tsx
@@ -42,6 +42,8 @@ const idModal = shortid.generate()
  * @param ariaLabelButtonClose {string} aria-label of button close
  * @param ariaLabelCta {string} aria-label of button action
  * @param titleButtonClose {string} title of button close
+ * @param ariaLabelButtonOpen {string} aria-label of open button modal
+ * @param titleButtonOpen {string} title of open button modal
  * - -------------------------- NATIVE PROPERTIES -------------------------------
  * @param bottom {boolean} If bottom
  * @param swipable {boolean} Swipable Native Modal

--- a/packages/react/components/modal/Modal.tsx
+++ b/packages/react/components/modal/Modal.tsx
@@ -10,6 +10,7 @@ import { ClickEvent, OnClickEvent } from "@/events/OnClickEvent"
 import { hashClass } from "@/helpers/hashClassesHelpers"
 import clsx from "clsx"
 import { useTrilogyContext } from "@/context/index"
+import shortid from "shortid"
 
 /**
  * Modal Component
@@ -67,6 +68,11 @@ const Modal = ({
   const modal = useRef<HTMLDivElement>(null)
   const [display, setDisplay] = useState<boolean>(active || false)
   const { styled } = useTrilogyContext()
+  const idDescription = shortid.generate()
+  const idTitle = shortid.generate()
+  const idModal = shortid.generate()
+  const ariaControls = `${idModal}-modal`
+  const refIconCloseModal = useRef<HTMLButtonElement>(null)
 
   const handleClickOutside = (e: Event) => {
     if (modal?.current?.contains(e.target as Node)) {
@@ -79,6 +85,10 @@ const Modal = ({
   useEffect(() => {
     setDisplay(active || false)
   }, [active])
+
+  useEffect(() => {
+    display && refIconCloseModal?.current && refIconCloseModal.current.focus()
+  }, [display,refIconCloseModal])
 
   useEffect(() => {
     if (display && !disableHandlingClickOutside) {
@@ -163,6 +173,7 @@ const Modal = ({
         handleClose(onCloseFunc, e)
       }}
       type={ButtonType.BUTTON}
+      {...{ title: 'Fermer la modal', ariaControls }}
     >
       Annuler
     </Button>
@@ -174,8 +185,11 @@ const Modal = ({
         handleClose(onCloseFunc, e)
       }}
       className={hashClass(styled, clsx("modal-close", is("large")))}
-      aria-label='close'
+      aria-label='Fermer la modal'
       type={ButtonType.BUTTON}
+      title="Fermer la modal"
+      aria-controls={ariaControls}
+      ref={refIconCloseModal}
     />
   )
 
@@ -183,6 +197,7 @@ const Modal = ({
     <div data-testid={testId}>
       {triggerContent && (
         <TriggerTag
+        aria-controls={ariaControls}
           onClick={(e: React.MouseEvent) => {
             handleOpen(onOpen, e)
           }}
@@ -191,16 +206,23 @@ const Modal = ({
           {triggerContent}
         </TriggerTag>
       )}
-      <div className={classes} {...others}>
+      <div 
+        className={classes} 
+        role="dialog" 
+        aria-modal="true" 
+        aria-labelledby={title ? idTitle : undefined} 
+        aria-describedby={content ? idDescription : undefined}
+        {...others} 
+      >
         <div ref={modal} className={contentClasses}>
           {closeIcon && <CloseButton onCloseFunc={onClose} />}
           {(title || iconName) && (
-            <ModalTitle iconColor={iconColor} iconName={iconName}>
+            <ModalTitle iconColor={iconColor} iconName={iconName} {...{textId:idTitle}}>
               {title}
             </ModalTitle>
           )}
           {content && typeof content === "string" ? (
-            <Text>{content}</Text>
+            <Text {...{id: idDescription}}>{content}</Text>
           ) : (
             content
           )}

--- a/packages/react/components/modal/Modal.tsx
+++ b/packages/react/components/modal/Modal.tsx
@@ -149,12 +149,13 @@ const Modal = ({
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       if (display && refsActions.current) {
+        const refs = refsActions.current.filter((ref) => ref)
         const { key } = event
         if (key === 'Tab') {
           event.preventDefault()
           setIndexFocusable((prev) => {
-            const nextIndex = (prev + 1) % refsActions.current.length
-            refsActions?.current[nextIndex] && refsActions?.current[nextIndex]?.focus()
+            const nextIndex = (prev + 1) % refs.length
+            refs[nextIndex] && refs[nextIndex]?.focus()
             return nextIndex
           })
         }
@@ -196,7 +197,7 @@ const Modal = ({
               type={ButtonType.BUTTON}
               title='Fermer la modal'
               aria-controls={ariaControls}
-              ref={(el) => (refsActions.current[0] = el)}
+              ref={(el) => el && (refsActions.current[0] = el)}
             />
           )}
           {(title || iconName) && (

--- a/packages/react/components/modal/ModalProps.ts
+++ b/packages/react/components/modal/ModalProps.ts
@@ -1,7 +1,7 @@
+import { IconColor, IconColorValues, IconName, IconNameValues } from '@/components/icon'
+import { ClickEvent } from '@/events/OnClickEvent'
 import { Accessibility, Clickable, Clipped, Fullwidth } from '@/objects'
 import { ModalMarkup, ModalMarkupValues } from './ModalEnum'
-import { ClickEvent } from '@/events/OnClickEvent'
-import { IconColor, IconColorValues, IconName, IconNameValues } from '@/components/icon'
 
 export interface ModalContentButtonProps extends Clickable {
   children?: string
@@ -39,4 +39,7 @@ export interface ModalProps extends Clipped, Fullwidth, Accessibility {
   onModalHide?: () => void
   disableHandlingClickOutside?: boolean
   swipable?: boolean
+  ariaLabelButtonClose?: string
+  ariaLabelCta?: string
+  titleButtonClose?: string
 }

--- a/packages/react/components/modal/ModalProps.ts
+++ b/packages/react/components/modal/ModalProps.ts
@@ -42,4 +42,6 @@ export interface ModalProps extends Clipped, Fullwidth, Accessibility {
   ariaLabelButtonClose?: string
   ariaLabelCta?: string
   titleButtonClose?: string
+  ariaLabelButtonOpen?: string
+  titleButtonOpen?: string
 }

--- a/packages/react/components/modal/title/ModalTitle.tsx
+++ b/packages/react/components/modal/title/ModalTitle.tsx
@@ -4,6 +4,7 @@ import { ModalTitleProps } from "./ModalTitleProps"
 import { hashClass } from "@/helpers"
 import clsx from "clsx"
 import { useTrilogyContext } from "@/context"
+import TextIcon from "@/components/icon/text/TextIcon"
 
 /**
  * Modal Title Component
@@ -16,19 +17,22 @@ const ModalTitle = ({
   children,
   className,
   iconColor,
-  iconName
+  iconName,
+  ...others
 }: ModalTitleProps): JSX.Element => {
   const { styled } = useTrilogyContext()
+  const {textId} = others as any
 
   return (
     <div className={hashClass(styled, clsx("modal-title", className))}>
       {iconName ? (
-        <Icon
+        <TextIcon
           color={iconColor}
           size={"large"}
           name={iconName}
           content={children}
           position='up'
+          textId={textId}
         />
       ) : (
         children

--- a/packages/react/components/modal/title/ModalTitle.tsx
+++ b/packages/react/components/modal/title/ModalTitle.tsx
@@ -1,10 +1,9 @@
-import * as React from "react"
-import { Icon } from "@/components/icon"
-import { ModalTitleProps } from "./ModalTitleProps"
-import { hashClass } from "@/helpers"
-import clsx from "clsx"
-import { useTrilogyContext } from "@/context"
-import TextIcon from "@/components/icon/text/TextIcon"
+import TextIcon from '@/components/icon/text/TextIcon'
+import { useTrilogyContext } from '@/context'
+import { hashClass } from '@/helpers'
+import clsx from 'clsx'
+import * as React from 'react'
+import { ModalTitleProps } from './ModalTitleProps'
 
 /**
  * Modal Title Component
@@ -13,26 +12,20 @@ import TextIcon from "@/components/icon/text/TextIcon"
  * @param iconName {IconName} IconName for icon title
  * @param iconColor {IconColor} IconColor for icon title
  */
-const ModalTitle = ({
-  children,
-  className,
-  iconColor,
-  iconName,
-  ...others
-}: ModalTitleProps): JSX.Element => {
+const ModalTitle = ({ children, className, iconColor, iconName, ...others }: ModalTitleProps): JSX.Element => {
   const { styled } = useTrilogyContext()
-  const {textId} = others as any
+  const { textId } = others as any
 
   return (
-    <div className={hashClass(styled, clsx("modal-title", className))}>
+    <div className={hashClass(styled, clsx('modal-title', className))} id={textId}>
       {iconName ? (
         <TextIcon
           color={iconColor}
-          size={"large"}
+          size={'large'}
           name={iconName}
           content={children}
           position='up'
-          textId={textId}
+          // textId={textId}
         />
       ) : (
         children

--- a/packages/styles/framework/src/theming/buttons_partial.scss
+++ b/packages/styles/framework/src/theming/buttons_partial.scss
@@ -24,8 +24,8 @@ $button-colors: (
     filter: brightness(0.7);
   }
 
-  &:focus-visible#{$noDisabled},
-  &:focus:focus-visible#{$noDisabled} {
+  &:focus-visible,
+  &:focus:focus-visible {
     outline: 2px solid getColor('font') !important;
     outline-offset: 2px;
   }

--- a/packages/styles/framework/src/theming/buttons_partial.scss
+++ b/packages/styles/framework/src/theming/buttons_partial.scss
@@ -1,3 +1,5 @@
+$noDisabled: ":not(:disabled):not([aria-disabled=true]):not(.is-loading)";
+
 /*
 Colors for buttons
   @string slug name used in classname (You can use your brand name)
@@ -22,9 +24,9 @@ $button-colors: (
     filter: brightness(0.7);
   }
 
-  &:focus-visible,
-  &:focus:focus-visible {
-    outline: var(--border-active);
+  &:focus-visible#{$noDisabled},
+  &:focus:focus-visible#{$noDisabled} {
+    outline: 2px solid getColor('font') !important;
     outline-offset: 2px;
   }
 }


### PR DESCRIPTION
Exemple de modal accessible :
`<Modal
          content="content"
          triggerMarkup={ModalMarkup.BUTTON}
          title="title modal"
          triggerContent="Open accessible modal"
          ctaContent="Action"
          ctaCancelOnClick={() => alert("cancel action")}
          ctaOnClick={() => alert("Click on cta")}
          onOpen={() => alert("open modal")}
          onClose={() => alert("close modal")}
          iconName={IconName.BELL}
          closeIcon
        />`

<img width="981" alt="Capture d’écran 2024-07-16 à 16 42 23" src="https://github.com/user-attachments/assets/f56b2085-ad41-48c1-ace3-e4373231f421">
