### PR TITLE
fix title when use subtitle overline props with typo props

### DIFF
--- a/packages/react/components/title/Title.tsx
+++ b/packages/react/components/title/Title.tsx
@@ -88,8 +88,8 @@ const Title = ({
     ),
   )
 
-  const subtitleClasses = hashClass(styled, clsx('subtitle', className))
-  const overlineClasses = hashClass(styled, clsx('overline', className))
+  const subtitleClasses = hashClass(styled, clsx('subtitle', typo, className))
+  const overlineClasses = hashClass(styled, clsx('overline', typo, className))
 
   useEffect(() => {
     setIsLoading(skeleton || false)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced styling logic for the `Title` component, allowing for dynamic class name generation based on typography.
- **Bug Fixes**
	- Improved visual representation of `subtitle` and `overline` elements through updated class name generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->