### PR TITLE
Adding sr-only class as in Bootstrap

### DIFF
--- a/packages/styles/framework/src/base/_a11y.scss
+++ b/packages/styles/framework/src/base/_a11y.scss
@@ -1,0 +1,11 @@
+.sr-only{
+  border: 0 !important;
+  clip: rect(1px,1px,1px,1px) !important;
+  clip-path: inset(50%) !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  width: 1px !important;
+  white-space: nowrap !important;
+}

--- a/packages/styles/framework/src/base/_all.scss
+++ b/packages/styles/framework/src/base/_all.scss
@@ -7,3 +7,4 @@
 @import "helpers";
 @import "loading";
 @import "elements";
+@import "a11y";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new CSS class `.sr-only` to improve accessibility by visually hiding elements while keeping them screen reader-friendly.
	- Expanded the base stylesheet to include accessibility-related styles with the addition of the "a11y" module import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->