### PR TITLE
display is true by default

### DIFF
--- a/examples/react-template/screens/Alert.tsx
+++ b/examples/react-template/screens/Alert.tsx
@@ -69,7 +69,6 @@ export const AlertScreen = (): JSX.Element => {
                 <Title level={TitleLevels.TWO}>StatusState : {status}</Title>
                 <Spacer size={10}/>
                 <Alert
-                  display
                   status={status}
                   title={status}
                   description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.."

--- a/examples/react-template/screens/Alert.tsx
+++ b/examples/react-template/screens/Alert.tsx
@@ -59,6 +59,13 @@ export const AlertScreen = (): JSX.Element => {
 
   return (
     <Section>
+      <Alert
+        banner
+        status={StatusState.INFO}
+        title="Banner Alert"
+        description="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.."
+      />
+
     <ToasterAlertProvider>
       <ToasterAlertView />
       <Container>

--- a/packages/react/components/alert/Alert.native.tsx
+++ b/packages/react/components/alert/Alert.native.tsx
@@ -55,6 +55,7 @@ const showToast: ToasterShowContext = (params: ToasterStatusProps) => {
  * @param display {Boolean} Display Alert component
  */
 const Alert = ({
+  banner,
   status,
   iconName,
   title,
@@ -72,10 +73,11 @@ const Alert = ({
       paddingTop: 10,
       borderColor: status !== undefined ? color : backgroundColor,
       paddingBottom: 10,
-      borderWidth: 1,
+      borderWidth: banner? 0 : 1,
       backgroundColor: backgroundColor,
-      borderRadius: 6,
+      borderRadius: banner? 0 : 6,
       alignItems: "baseline",
+      textAlign: banner? 'center' : 'left',
       paddingLeft: 12,
       paddingRight: 12,
     },

--- a/packages/react/components/alert/Alert.native.tsx
+++ b/packages/react/components/alert/Alert.native.tsx
@@ -60,7 +60,7 @@ const Alert = ({
   title,
   description,
   onClick,
-  display,
+  display = true,
   ...others
 }: AlertProps): JSX.Element => {
   const { color, backgroundColor } = getStatusStyle(status)

--- a/packages/react/components/alert/Alert.tsx
+++ b/packages/react/components/alert/Alert.tsx
@@ -107,7 +107,7 @@ const Alert = ({
   title,
   description,
   onClick,
-  display,
+  display = true,
   testId,
   ...others
 }: AlertProps): JSX.Element => {

--- a/packages/react/components/alert/Alert.tsx
+++ b/packages/react/components/alert/Alert.tsx
@@ -101,6 +101,7 @@ const ToasterAlert: React.FC<{ props: ToasterStatusProps }> = ({ props, ...other
  * @param testId {string} Test Id for Test Integration
  */
 const Alert = ({
+  banner,
   status,
   className,
   iconName,
@@ -115,7 +116,7 @@ const Alert = ({
 
   const classes = hashClass(
     styled,
-    clsx("alert", has("body"), status && is(getStatusClassName(status)), className)
+    clsx("alert", has("body"), status && is(getStatusClassName(status)), banner && is('banner'), className)
   )
 
   const iconAlert = React.useMemo(() => {

--- a/packages/react/components/alert/AlertProps.ts
+++ b/packages/react/components/alert/AlertProps.ts
@@ -35,4 +35,5 @@ export interface AlertProps extends StatusProps, Clickable, Accessibility {
   className?: string
   display?: boolean
   toaster?: boolean
+  banner?: boolean
 }

--- a/packages/styles/framework/src/elements/_alert.scss
+++ b/packages/styles/framework/src/elements/_alert.scss
@@ -18,6 +18,14 @@ a.alert {
   box-shadow: none;
   padding: $spacing-4;
 
+  &.is-banner {
+
+    text-align: center;
+    border-radius: 0;
+    border: none !important;
+
+  }
+
   .text:first-child,
   .title:first-child {
     line-height: normal;

--- a/packages/styles/framework/src/elements/_paragraph.scss
+++ b/packages/styles/framework/src/elements/_paragraph.scss
@@ -13,7 +13,9 @@ $text-levels-mobile: (
 
 
 .text {
-        @each $text-level in $text-levels {
+  line-height: $text-20;
+
+  @each $text-level in $text-levels {
             $i: index($text-levels, $text-level);
             $font-size: nth($text-level, 1);
             $line-height: nth($text-level, 2);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `Alert` component now has a default `display` value set to `true`, simplifying its usage by eliminating the need to specify this prop explicitly.
  
- **Bug Fixes**
	- Removed the `display` prop from the `Alert` component in the `ToasterAlertView`, which may enhance its visibility and behavior in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->