### PR TITLE
Remove ButtonList mobile property

### DIFF
--- a/packages/react/components/button/list/ButtonList.tsx
+++ b/packages/react/components/button/list/ButtonList.tsx
@@ -18,7 +18,6 @@ import { useTrilogyContext } from "@/context"
 const ButtonList = ({
   className,
   centered,
-  isMobile,
   vertical,
   ...others
 }: ButtonListWebProps): JSX.Element => {
@@ -32,7 +31,6 @@ const ButtonList = ({
           "buttons",
           className,
           centered && has("text-centered"),
-          isMobile && "is-mobile",
           vertical && "is-vertical"
         )
       )}

--- a/packages/react/components/button/list/ButtonListProps.ts
+++ b/packages/react/components/button/list/ButtonListProps.ts
@@ -16,6 +16,5 @@ export interface ButtonListProps extends Layout {
  */
 export interface ButtonListWebProps extends ButtonListProps, Centerable {
   className?: string
-  isMobile?: boolean
   vertical?: boolean
 }

--- a/packages/styles/framework/src/elements/_button.scss
+++ b/packages/styles/framework/src/elements/_button.scss
@@ -19,14 +19,6 @@ $button-border-width: 2px !default;
   .has-text-centered & {
     justify-content: center;
   }
-
-  &.is-mobile {
-    flex-wrap: wrap;
-
-    .button {
-      margin-bottom: 16px;
-    }
-  }
 }
 
 .button {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined the `ButtonList` component by removing the `isMobile` prop, enhancing simplicity.
  
- **Bug Fixes**
	- Eliminated the `.is-mobile` class and its styles, ensuring consistent button behavior across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->