### PR TITLE
:bug: Fix Accordion overflow

### DIFF
--- a/packages/styles/framework/src/components/_accordion.scss
+++ b/packages/styles/framework/src/components/_accordion.scss
@@ -32,6 +32,7 @@
     .accordion-body {
       padding: $spacing-4;
       padding-top: 0 !important;
+      box-sizing: border-box;
     }
 
     &:has(summary:hover):not(.is-disabled)  {


### PR DESCRIPTION
Avant :
![image](https://github.com/user-attachments/assets/00230736-6daa-4bec-bc4b-ad962886e66e)

Après:
<img width="666" alt="image" src="https://github.com/user-attachments/assets/73354782-dd0b-4b2c-95f2-c85be014d8cd" />


Close #259 