### PR TITLE
delete margin from next/previous element divider 

### DIFF
--- a/examples/react-template/screens/Divider.tsx
+++ b/examples/react-template/screens/Divider.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react'
-import { Box, BoxContent, Divider, IconName, Section, Text } from '@trilogy-ds/react/components'
 import { Row, Rows, Spacer, SpacerSize } from '@trilogy-ds/react'
+import { Box, BoxContent, Divider, IconName, Section, Text } from '@trilogy-ds/react/lib/components'
 import { GapSize } from '@trilogy-ds/react/lib/components/columns/ColumnsTypes'
+import * as React from 'react'
 
 export const DividerScreen = (): JSX.Element => {
   return (

--- a/packages/react/components/divider/Divider.tsx
+++ b/packages/react/components/divider/Divider.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react'
-import { DividerProps } from './DividerProps'
-import { is, has } from '@/services/classify'
-import { Icon, IconSize } from '../icon'
-import clsx from 'clsx'
-import { hashClass } from '@/helpers'
+import { DividerProps } from '@/components/divider/DividerProps'
+import { Icon, IconSize } from '@/components/icon'
 import { useTrilogyContext } from '@/context'
+import { hashClass } from '@/helpers/hashClassesHelpers'
+import { has, is } from '@/services/classify'
+import clsx from 'clsx'
+import React from 'react'
 
 /**
  * Divider Component

--- a/packages/styles/framework/src/components/_autolayout.scss
+++ b/packages/styles/framework/src/components/_autolayout.scss
@@ -14,12 +14,6 @@ body:not(.is-tight) {
   .box:not(:last-child) {
     margin-bottom: 24px;
   }
-  *:has(+ .divider):not(:last-child) {
-    margin-bottom: 24px;
-  }
-  .divider:not(:last-child) {
-    margin-bottom: 24px;
-  }
   .table:not(:last-child) {
     margin-bottom: 24px;
   }
@@ -181,12 +175,6 @@ body:not(.is-tight) {
       margin-bottom: 16px;
     }
   .box:not(:last-child) {
-      margin-bottom: 16px;
-    }
-  *:has(+ .divider):not(:last-child) {
-      margin-bottom: 16px;
-    }
-  .divider:not(:last-child) {
       margin-bottom: 16px;
     }
   .table:not(:last-child) {

--- a/packages/styles/framework/src/components/_divider.scss
+++ b/packages/styles/framework/src/components/_divider.scss
@@ -4,7 +4,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  margin: $spacing-5 0;
 
   p.divider-content {
     white-space: nowrap;
@@ -12,8 +11,12 @@
     background-color: invertColor('neutral');
   }
 
+  &:not(.is-marginless) {
+    margin: $spacing-5 0;
+  }
+
   @include mobile {
-    & {
+    &:not(.is-marginless) {
       margin: $spacing-4 0;
     }
   }

--- a/packages/styles/framework/src/components/_divider.scss
+++ b/packages/styles/framework/src/components/_divider.scss
@@ -4,10 +4,23 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  margin: $spacing-5 0;
 
   p.divider-content {
     white-space: nowrap;
     padding: 0 $spacing-4;
     background-color: invertColor('neutral');
   }
+
+  @include mobile {
+    & {
+      margin: $spacing-4 0;
+    }
+  }
 }
+
+*:has(+ .divider) {
+  margin-top: 0 !important; 
+  margin-bottom: 0 !important;
+}
+

--- a/packages/styles/scripts/autolayout.ts
+++ b/packages/styles/scripts/autolayout.ts
@@ -19,8 +19,6 @@ export const DEFAULT_SPACING_MATRIX: DefaultSpacingMatrix = [
   [INSERT_SPACE_BETWEEN, '.card', 'default', FIVE, FOUR],
   [INSERT_SPACE_BETWEEN, '.columns', 'default', FIVE, FOUR],
   [INSERT_SPACE_BETWEEN, '.box', 'default', FIVE, FOUR],
-  [INSERT_SPACE_BETWEEN, '*:has(+ .divider)', 'default', FIVE, FOUR],
-  [INSERT_SPACE_BETWEEN, '.divider', 'default', FIVE, FOUR],
   [INSERT_SPACE_BETWEEN, '.table', 'default', FIVE, FOUR],
   [INSERT_SPACE_BETWEEN, '.list', 'default', FIVE, FOUR],
   [INSERT_SPACE_BETWEEN, '.timeline', 'default', FIVE, FOUR],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated import paths for Divider component across different files
	- Refined CSS rules for `.divider` spacing
	- Removed default margin-bottom rules for divider elements

- **Refactor**
	- Reorganized import statements in Divider and related components
	- Simplified React import syntax

The changes primarily focus on internal code structure and styling consistency for the Divider component, with no significant user-facing modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->