### PR TITLE
Fix color in container inside inverted section or hero

### DIFF
--- a/examples/react-template/screens/Hero.tsx
+++ b/examples/react-template/screens/Hero.tsx
@@ -20,13 +20,15 @@ export const HeroScreen = (): JSX.Element => {
   return (
     <Section>
       <Hero backgroundColor={TrilogyColor.MAIN} overlap inverted>
-          <Title markup={TitleMarkup.H1} level={TitleLevels.TWO}>
+        <Container>
+        <Title markup={TitleMarkup.H1} level={TitleLevels.TWO}>
             Hero Overlapped
           </Title>
           <Text level={TextLevels.TWO}>
             Profitez dInternet dès labonnement et même en cas de coupure grâce à
             une clé 4G dans les nouvelles offres Bbox.
           </Text>
+        </Container>
       </Hero>
       <Section>
         <Container>

--- a/packages/styles/framework/src/utilities/_background.scss
+++ b/packages/styles/framework/src/utilities/_background.scss
@@ -3,7 +3,7 @@
 }
 
 .is-inverted {
-  .box, .section, .container, .view, .hero {
+  .box, .section, .view, .hero {
     &:not(.is-inverted) {
       color: getColor('font');
     }


### PR DESCRIPTION
Fix color in container inside inverted section or hero (Bytel#15)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
	- Enhanced `Hero` section layout by adding a `Container` component around the `Title`
	- Updated background styling for `.is-inverted` class, removing `.container` from nested selectors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->