### PR TITLE
Feature/checkbox children

### DIFF
--- a/examples/react-template/screens/Checkbox.tsx
+++ b/examples/react-template/screens/Checkbox.tsx
@@ -25,6 +25,9 @@ export const CheckboxScreen = (): JSX.Element => {
             <Checkbox name='name-1' label='Label' value='value' id='checkbox2' />
             <Checkbox name='name-1' label='Label' value='value' disabled id='checkbox3' />
             <Checkbox name='name-1' label='Label' value='value' readonly id='checkbox4' />
+            <Checkbox name='name-1' value='value' id='checkbox5'>
+              Multi line <br/> label with <strong>HTML</strong>.
+            </Checkbox>
           </Column>
           <Column size={12} align={Alignable.ALIGNED_CENTER}>
             <CheckboxTiles align={Alignable.ALIGNED_CENTER} verticalAlign={Alignable.ALIGNED_CENTER}>

--- a/packages/react/components/checkbox/Checkbox.tsx
+++ b/packages/react/components/checkbox/Checkbox.tsx
@@ -11,9 +11,10 @@ import { useTrilogyContext } from '@/context'
  * @param disabled {boolean} Disabled
  * @param readOnly {boolean} readonly Checkbox
  * @param id {string} Id for button, by default id is generate
- * @param label {string} Label for Checkbox
+ * @param label {string} Label for Checkbox // Incompatible with children
  * @param onChange {ChangeEvent}
  * @param name {string} Name for checkbox
+ * @param children {React.ReactNode} Children for Checkbox, should be only [phrasing content](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#technical_summary)
  * - -------------------------- WEB PROPERTIES -------------------------------
  * @param value {string} Value for checkbox
  * @param className {string} Additionnal css classes (ONLY FOR WEB)
@@ -28,6 +29,7 @@ const Checkbox = ({
   onChange,
   name,
   value,
+  children,
   ...others
 }: CheckboxProps): JSX.Element => {
   const { styled } = useTrilogyContext()
@@ -54,7 +56,7 @@ const Checkbox = ({
         {...others}
       />
       <label htmlFor={id} className={hashClass(styled, clsx('checkbox-label'))}>
-        {label}
+        {label ?? children}
       </label>
     </div>
   )

--- a/packages/react/components/checkbox/CheckboxProps.ts
+++ b/packages/react/components/checkbox/CheckboxProps.ts
@@ -1,5 +1,6 @@
 import { Accessibility } from '../../objects'
 import { CommonProps } from '../../objects/facets/CommonProps'
+import React from 'react'
 
 type CheckboxChangeEventHandler = (event: {
   checkboxValue: string
@@ -11,12 +12,24 @@ type CheckboxChangeEventHandler = (event: {
 /**
  * Checkbox Interface
  */
-export interface CheckboxProps extends Accessibility, CommonProps {
+export type CheckboxProps = Pick<CheckboxPropsPossibilities, keyof CheckboxPropsPossibilities>
+type CheckboxPropsPossibilities = CheckboxWithLabel | CheckboxWithChildren;
+
+interface CheckboxCommonProps extends Accessibility, CommonProps {
   checked?: boolean
   disabled?: boolean
   readonly?: boolean
-  label?: string
   onChange?: CheckboxChangeEventHandler
   name?: string
   value?: string
+}
+
+interface CheckboxWithLabel extends CheckboxCommonProps {
+  label: string
+  children?: never
+}
+
+interface CheckboxWithChildren extends CheckboxCommonProps {
+  children: React.ReactNode
+  label?: never
 }


### PR DESCRIPTION
# Issue :
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#technical_summary), a label can contain [phrasing content](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content). Actually, only text through `label` prop can be provided.

# Changes :
- Add children prop
- Add type to make `label` and `children` incompatible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new checkbox with a multi-line label that supports HTML formatting, offering a more dynamic and visually engaging presentation.
  - Enhanced flexibility in checkbox labeling by allowing the display of custom formatted content alongside standard text labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->