### PR TITLE
:lipstick: Change Badge.native size to 10px

### DIFF
--- a/packages/react/components/badge/Badge.native.tsx
+++ b/packages/react/components/badge/Badge.native.tsx
@@ -40,8 +40,8 @@ const Badge = ({
     },
     badge: {
       alignSelf: 'baseline',
-      minWidth: label ? 20 : 12,
-      height: label ? 20 : 12,
+      minWidth: label ? 20 : 10,
+      height: label ? 20 : 10,
       backgroundColor: !inverted ? badgeColor : getColorStyle(TrilogyColor.BACKGROUND),
       borderRadius: 30,
       justifyContent: 'center',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the visual design of the Badge component by reducing its default sizing when no text label is present. This adjustment creates a sleeker, more balanced appearance that integrates seamlessly with surrounding interface elements. The refined dimensions provide a more consistent presentation and enhanced visual experience for users across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->