### PR TITLE
:lipstick: Add Typography center props on link.native

### DIFF
--- a/examples/react-template/screens/Link.tsx
+++ b/examples/react-template/screens/Link.tsx
@@ -1,14 +1,12 @@
 import * as React from 'react'
 import { IconName, Link, Section, Text, Title, TitleLevels } from '@trilogy-ds/react/components'
-import { Divider } from '@trilogy-ds/react'
+import { Divider, TrilogyColor, TypographyAlign, View } from '@trilogy-ds/react'
 
 export const LinkScreen = (): JSX.Element => {
   return (
     <Section>
       <Title level={TitleLevels.THREE}>Links inline</Title>
-      <Link iconName={IconName.ARROW_DOWN}>
-        Link with arrow
-      </Link>
+      <Link iconName={IconName.ARROW_DOWN}>Link with arrow</Link>
 
       <Text>
         I'm in a paragraph and this is a <Link>standard link</Link> while this is a{' '}
@@ -29,6 +27,20 @@ export const LinkScreen = (): JSX.Element => {
       <Link href='https://example.com' iconName={IconName.SEARCH} data-testid={'test-icon'}>
         Example
       </Link>
+
+      <Divider />
+      <Title level={TitleLevels.THREE}>Centered links</Title>
+      <View backgroundColor={TrilogyColor.INFO_FADE}>
+        <Link inline typo={TypographyAlign.TEXT_LEFT}>
+          LEFT - This is a test
+        </Link>
+        <Link inline typo={TypographyAlign.TEXT_CENTERED}>
+          CENTERED - This is a test
+        </Link>
+        <Link inline typo={TypographyAlign.TEXT_RIGHT}>
+          RIGHT - This is a test
+        </Link>
+      </View>
     </Section>
   )
 }

--- a/packages/react/components/link/Link.native.tsx
+++ b/packages/react/components/link/Link.native.tsx
@@ -5,6 +5,7 @@ import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import * as React from 'react'
 import { Linking, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { LinkPropsNative } from './LinkProps'
+import { setTypographyAlign, TypographyAlign } from '@/objects'
 
 /**
  * Link Component
@@ -19,19 +20,24 @@ import { LinkPropsNative } from './LinkProps'
  * @param inverted {boolean} Inverted link
  */
 const Link = ({
-                children,
-                to,
-                onClick,
-                testId,
-                accessibilityLabel,
-                inline,
-                iconName,
-                inverted,
-                ...others
-              }: LinkPropsNative): JSX.Element => {
+  children,
+  to,
+  onClick,
+  testId,
+  accessibilityLabel,
+  inline,
+  iconName,
+  inverted,
+  typo,
+  ...others
+}: LinkPropsNative): JSX.Element => {
   const styles = StyleSheet.create({
     linkAlignement: {
-      alignSelf: 'baseline',
+      alignSelf:
+        (setTypographyAlign(typo) === 'left' && 'flex-start') ||
+        (setTypographyAlign(typo) === 'center' && 'center') ||
+        (setTypographyAlign(typo) === 'right' && 'flex-end') ||
+        'flex-start',
     },
     container: {
       padding: inline ? 4 : 8,
@@ -72,8 +78,8 @@ const Link = ({
   const linkAccessibilityLabel = accessibilityLabel
     ? accessibilityLabel
     : typeof children === 'string'
-      ? children
-      : 'NotSpecified'
+    ? children
+    : 'NotSpecified'
 
   return (
     <View

--- a/packages/react/components/link/LinkProps.ts
+++ b/packages/react/components/link/LinkProps.ts
@@ -3,6 +3,7 @@ import { Role } from 'react-native'
 import { IconName, IconNameValues } from '../../components/icon'
 import { Accessibility, Clickable, Dev } from '../../objects/facets'
 import { CommonProps } from '../../objects/facets/CommonProps'
+import { TypographyAlign, TypographyAlignValues } from '@/objects'
 
 /**
  * Link Interface
@@ -26,4 +27,5 @@ export interface LinkProps extends Link {
 
 export interface LinkPropsNative extends Link {
   role?: Role
+  typo?: TypographyAlign | TypographyAlignValues
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced link components now support configurable text alignment, including a centered display option.
  - Introduced a dedicated section showcasing centered links with a distinctive background style.

- **Style**
  - Improved visual organization by adding dividers to clearly separate different link sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->