### PR TITLE
🐛 Fix onBackDropPress Modal.native

### DIFF
--- a/packages/react/components/modal/Modal.native.tsx
+++ b/packages/react/components/modal/Modal.native.tsx
@@ -67,6 +67,7 @@ const Modal = ({
       {trigger}
       <ModalRN
         isVisible={visible}
+        onBackdropPress={() => handleClose({} as GestureResponderEvent)}
         onSwipeComplete={handleClose}
         swipeDirection={unClosable ? undefined : ['down']}
         scrollTo={handleScrollTo}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved modal behavior: The modal now closes when users tap on the backdrop, enhancing the overall user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->