### PR TITLE
🐛 Fix alert description props default alignment

### DIFF
--- a/examples/react-template/screens/Alert.tsx
+++ b/examples/react-template/screens/Alert.tsx
@@ -11,14 +11,19 @@ import {
   IconName,
   Button,
   Section,
+  Link,
+  TextLevels,
   SpacerSize,
   Text,
+  Column,
+  Columns,
 } from '@trilogy-ds/react/components'
 import { StatusState } from '@trilogy-ds/react/objects'
 import { useContext, useState } from 'react'
 import ToasterContext from '@trilogy-ds/react/lib/components/alert/context/ToasterContext'
 import { ToasterAlertProvider } from '@trilogy-ds/react/lib/components/alert'
 import { ToasterAlertFloat, ToasterAlertPosition } from '@trilogy-ds/react/lib/components/alert/AlertProps'
+import { Alignable } from '@trilogy-ds/react'
 
 export const AlertScreen = (): JSX.Element => {
   const ToasterAlertView: React.FC = () => {
@@ -76,8 +81,29 @@ export const AlertScreen = (): JSX.Element => {
             <Text>Test React.NODE</Text>
             <Text>Test React.NODE</Text>
             <Text>Test React.NODE</Text>
+            <Columns align={Alignable.ALIGNED_CENTER}>
+              <Column narrow>
+                <Spacer size={SpacerSize.TWO} />
+                <Link>Link should be ALIGNED_CENTER</Link>
+              </Column>
+            </Columns>
           </>
         }
+      />
+      <Spacer size={SpacerSize.EIGHT} />
+
+      <Alert
+        description={
+          <>
+            <Text level={TextLevels.TWO}>{'Text description'}</Text>
+            <Spacer size={SpacerSize.TWO} />
+            <Link>Link should be ALIGNED_START</Link>
+          </>
+        }
+        display={true}
+        iconName={IconName.ALERT}
+        status={StatusState.WARNING}
+        title='Test title'
       />
 
       <ToasterAlertProvider>

--- a/packages/react/components/alert/Alert.native.tsx
+++ b/packages/react/components/alert/Alert.native.tsx
@@ -78,7 +78,6 @@ const Alert = ({
     },
     description: {
       justifyContent: 'center',
-      alignItems: 'center',
       textAlignVertical: 'center',
       paddingLeft: 8,
     },

--- a/packages/react/components/link/Link.native.tsx
+++ b/packages/react/components/link/Link.native.tsx
@@ -1,10 +1,10 @@
-import {ComponentName} from '@/components/enumsComponentsName'
-import {Icon} from '@/components/icon'
-import {getColorStyle, TrilogyColor} from '@/objects/facets/Color'
+import { ComponentName } from '@/components/enumsComponentsName'
+import { Icon } from '@/components/icon'
+import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import * as React from 'react'
-import {useState} from 'react'
-import {Linking, StyleSheet, Text, View,} from 'react-native'
-import {LinkPropsNative} from './LinkProps'
+import { useState } from 'react'
+import { Linking, StyleSheet, Text, View } from 'react-native'
+import { LinkPropsNative } from './LinkProps'
 
 /**
  * Link Component
@@ -30,9 +30,6 @@ const Link = ({
   const [pressedLink, setPressedLink] = useState(false)
 
   const styles = StyleSheet.create({
-    linkAlignement: {
-      alignSelf: 'baseline',
-    },
     link: {
       color: getColorStyle(pressedLink && TrilogyColor.MAIN_FADE || inverted && TrilogyColor.BACKGROUND || TrilogyColor.MAIN),
       fontSize: 14,


### PR DESCRIPTION
## Changelog

### Fixed

- Corrected default alignment of the description props in the `Alert` component.
- Removed an unused CSS class  `linkAlignement` in the `Link.native` component.


| Alert - Before | Alert - After |
|--------|--------|
|![Simulator Screenshot - MCare - 2025-02-19 at 00 00 52](https://github.com/user-attachments/assets/d10b0727-2ac2-460e-ada7-181985a08036)|![Simulator Screenshot - MCare - 2025-02-19 at 00 07 27](https://github.com/user-attachments/assets/832f88ad-3fe5-4ac0-9921-8af96b95d4cc) |
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned alert views now feature enriched descriptive content with interactive text and clickable links for an engaging user experience.
  - Enhanced layout organization introduces clear separation and alignment, improving the overall interface structure.

- **Style**
  - Refined visual adjustments ensure balanced spacing and alignment across alert and link elements, delivering a more cohesive presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->