### PR TITLE
Add fullheight props for Columns

### DIFF
--- a/examples/react-template/screens/Column.tsx
+++ b/examples/react-template/screens/Column.tsx
@@ -1,14 +1,35 @@
-import { Alignable, IconName, IconSize, Spacer, SpacerSize, Text, Title } from '@trilogy-ds/react'
-import { Box, BoxContent, Column, Columns, GapSize, Icon, Section } from '@trilogy-ds/react/components'
+import {Alignable, IconName, IconSize, Spacer, SpacerSize, Text, Title} from '@trilogy-ds/react'
+import {Box, BoxContent, Column, Columns, GapSize, Icon, Section} from '@trilogy-ds/react/components'
 import * as React from 'react'
-import { View } from 'react-native'
+import {View} from 'react-native'
 
 export const ColumnScreen = (): JSX.Element => {
   const refColumn = React.useRef<any>([])
 
   return (
     <Section>
-      <Columns gap={GapSize.THREE}>
+      <Columns>
+        <Column>
+          <Box fullheight>
+            <Columns verticalAlign={"ALIGNED_CENTER"} fullheight>
+              <Column>
+                <Text>Box 1</Text>
+              </Column>
+            </Columns>
+          </Box>
+        </Column>
+        <Column>
+          <Box fullheight>
+            <Text>Box 2</Text>
+            <Text>Box 2</Text>
+            <Text>Box 2</Text>
+            <Text>Box 2</Text>
+            <Text>Box 2</Text>
+          </Box>
+        </Column>
+      </Columns>
+
+  <Columns gap={GapSize.THREE}>
         <Column narrow>
           <Box flat>
             <BoxContent>Column </BoxContent>

--- a/packages/react/components/columns/Columns.native.tsx
+++ b/packages/react/components/columns/Columns.native.tsx
@@ -16,7 +16,7 @@ import { Dimensions, LayoutChangeEvent, ScrollView, StyleSheet, View } from 'rea
  */
 
 const Columns = React.forwardRef<ColumnsNativeRef, ColumnsProps>(
-  ({ children, align, gap, verticalAlign, fullBleed, scrollable, multiline, ...others }, ref): JSX.Element => {
+  ({ children, align, gap, verticalAlign, fullBleed, scrollable, multiline, fullheight, ...others }, ref): JSX.Element => {
     const [width, setWidth] = useState(0)
     const [enlarge, setEnlarge] = useState(0)
 
@@ -42,6 +42,7 @@ const Columns = React.forwardRef<ColumnsNativeRef, ColumnsProps>(
         paddingHorizontal: enlarge,
         flexDirection: 'row',
         gap: realGap,
+        height: fullheight ? '100%' : 'auto'
       },
       centered: {
         justifyContent: 'center',

--- a/packages/react/components/columns/Columns.tsx
+++ b/packages/react/components/columns/Columns.tsx
@@ -23,7 +23,7 @@ import React from 'react'
  */
 const Columns = React.forwardRef<ColumnsRef, ColumnsProps>(
   (
-    { className, id, multiline, scrollable, mobile, gap, fullBleed, marginless, align, verticalAlign, ...others },
+    { className, id, multiline, scrollable, mobile, gap, fullBleed, marginless, align, verticalAlign, fullheight, ...others },
     ref,
   ) => {
     const { styled } = useTrilogyContext()
@@ -41,6 +41,7 @@ const Columns = React.forwardRef<ColumnsRef, ColumnsProps>(
         align && is(getJustifiedClassName(align)),
         verticalAlign && is(getAlignClassName(verticalAlign)),
         marginless && is(`marginless`),
+        fullheight && is('fullheight'),
         className,
       ),
     )

--- a/packages/react/components/columns/ColumnsProps.ts
+++ b/packages/react/components/columns/ColumnsProps.ts
@@ -14,6 +14,7 @@ export interface ColumnsProps extends AlignableProps, CommonProps {
   fullBleed?: boolean
   mobile?: boolean
   marginless?: boolean
+  fullheight?: boolean
 }
 
 export type ColumnsRef = HTMLDivElement


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The column screen layout has been refreshed with the addition of new content blocks for a more engaging and organized display.
	- A new full-height option is now available for column layouts, allowing sections to expand to their container’s full height for improved visual balance and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->