### PR TITLE
🐛 Fix mobile tabs

### DIFF
--- a/packages/styles/framework/src/components/_tabs.scss
+++ b/packages/styles/framework/src/components/_tabs.scss
@@ -12,10 +12,6 @@
   -ms-overflow-style: none !important;
   scrollbar-width: none;
 
-  @include mobile {
-    text-align: left;
-  }
-
   &::-webkit-scrollbar {
     width: 0 !important;
     height: 0 !important;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the tab styling for consistent visual alignment across all devices by removing the mobile-specific left text alignment override. The default styling now applies universally to the tab elements without adjustments for mobile views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->