### PR TITLE
Add silenceDeprecations rules

### DIFF
--- a/packages/styles/vite.config.js
+++ b/packages/styles/vite.config.js
@@ -22,6 +22,7 @@ export default defineConfig({
     postcss: {},
     preprocessorOptions: {
       scss: {
+        silenceDeprecations: ['import', 'legacy-js-api', 'mixed-decls', 'global-builtin' ],
         additionalData: `@use './framework/src/all' as *;`,
         sassOptions: {
           includePaths: ['./themes'],


### PR DESCRIPTION
Silence deprecation for Dart, we search a real alternative as @use work only with Dart Sass and need a complete rework and complexe theming possibilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted the styling build configuration to suppress non-critical warning messages during SCSS processing, ensuring a cleaner and smoother development experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->