### PR TITLE
Fix textarea wrapper display

### DIFF
--- a/packages/styles/framework/src/elements/_textarea.scss
+++ b/packages/styles/framework/src/elements/_textarea.scss
@@ -1,4 +1,5 @@
 .textarea-wrapper {
+  display: inline;
   position: relative;
   margin: 16px 0;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the text area container's display to inline, allowing it to integrate seamlessly with surrounding elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->