### PR TITLE
Add readOnly props for Input

### DIFF
--- a/examples/react-template/screens/Input.tsx
+++ b/examples/react-template/screens/Input.tsx
@@ -10,6 +10,8 @@ import {
   Section,
   Title,
   TitleLevels,
+  SpacerSize,
+  Spacer
 } from '@trilogy-ds/react/components'
 import * as React from 'react'
 import { useEffect } from 'react'
@@ -43,6 +45,14 @@ export const InputScreen = (): JSX.Element => {
 
   return (
     <Section backgroundColor={TrilogyColor.BACKGROUND}>
+      <Input
+        value={'ReadOnly Input value'}
+        label='ReadOnly input'
+        help='ReadOnly input'
+        placeholder="ReadOnly input"
+        readOnly
+      />
+
       {!isMobile && (
         <form onSubmit={form.handleSubmit((data) => alert(JSON.stringify(data)))}>
           <Input {...form.register('toto', { required: true })} accessibilityLabel='label' label='label' />
@@ -50,7 +60,7 @@ export const InputScreen = (): JSX.Element => {
         </form>
       )}
 
-      {/*<Spacer size={SpacerSize.FIVE}/>*/}
+      <Spacer size={SpacerSize.FIVE}/>
 
       <Input
         value={inputSearch}

--- a/examples/react-template/screens/Input.tsx
+++ b/examples/react-template/screens/Input.tsx
@@ -45,6 +45,7 @@ export const InputScreen = (): JSX.Element => {
 
   return (
     <Section backgroundColor={TrilogyColor.BACKGROUND}>
+      <Title level={4}>Readonly input</Title>
       <Input
         value={'ReadOnly Input value'}
         label='ReadOnly input'

--- a/examples/react-template/screens/Input.tsx
+++ b/examples/react-template/screens/Input.tsx
@@ -1,4 +1,4 @@
-import { isMobile, Spacer, TrilogyColor } from '@trilogy-ds/react'
+import { isMobile, Spacer, SpacerSize, TrilogyColor } from '@trilogy-ds/react'
 import {
   AutoLayout,
   Button,
@@ -10,8 +10,6 @@ import {
   Section,
   Title,
   TitleLevels,
-  SpacerSize,
-  Spacer
 } from '@trilogy-ds/react/components'
 import * as React from 'react'
 import { useEffect } from 'react'
@@ -55,7 +53,6 @@ export const InputScreen = (): JSX.Element => {
       />
 
       <Title level={4}>Input react-hook-form control</Title>
-
       {!isMobile && (
         <form onSubmit={form.handleSubmit((data) => alert(JSON.stringify(data)))}>
           <Input {...form.register('toto', { required: true })} accessibilityLabel='label' label='label' />
@@ -65,8 +62,6 @@ export const InputScreen = (): JSX.Element => {
           <Spacer size={SpacerSize.FIVE} />
         </form>
       )}
-
-      <Spacer size={SpacerSize.FIVE}/>
 
       <Title level={4}>Input with label and without accessibilityLabel</Title>
       <Input
@@ -78,7 +73,6 @@ export const InputScreen = (): JSX.Element => {
         iconNameLeft={IconName.ARROW_LEFT}
         accessibilityLabel='Input label not dynamic with sample'
       />
-
       <Spacer size={SpacerSize.FIVE} />
 
       <Title level={4}>Input without label and with accessibilityLabel</Title>

--- a/packages/react/components/input/Input.native.tsx
+++ b/packages/react/components/input/Input.native.tsx
@@ -94,6 +94,7 @@ const Input = React.forwardRef<InputNativeRef, InputNativeProps>(({
   validationRules,
   onIconClick,
   required,
+  readOnly,
   ...others
 }, ref): JSX.Element => {
   const inputTestId = testId ? testId : placeholder ? placeholder : 'NotSpecified'
@@ -337,6 +338,7 @@ const Input = React.forwardRef<InputNativeRef, InputNativeProps>(({
         <TextInput
           ref={ref}
           testID='input-id'
+          readOnly={readOnly}
           clearTextOnFocus={false}
           secureTextEntry={!!(type && type === InputType.PASSWORD && iconPassword === IconName.EYE)}
           value={value}

--- a/packages/react/components/input/Input.native.tsx
+++ b/packages/react/components/input/Input.native.tsx
@@ -63,6 +63,7 @@ export interface InputNativeProps extends InputProps, InputNativeEvents {}
  * @param testId {string} Test Id for Test Integration
  * @param required {boolean} Required input
  * @param accessibilityActivate {boolean}
+ * @param readOnly {boolean} Read only input
  */
 const Input = React.forwardRef<InputNativeRef, InputNativeProps>(({
   defaultValue,

--- a/packages/react/components/input/Input.tsx
+++ b/packages/react/components/input/Input.tsx
@@ -103,6 +103,7 @@ const Input = React.forwardRef<InputRef, InputProp>(
       securityGauge,
       validationRules,
       required,
+      readOnly,
       ...others
     },
     ref,
@@ -233,6 +234,7 @@ const Input = React.forwardRef<InputRef, InputProp>(
             id={id}
             required={required}
             role='textbox'
+            readOnly={readOnly}
             {...others}
             aria-label={!label ? accessibilityLabel : undefined}
             type={inputType}

--- a/packages/react/components/input/Input.tsx
+++ b/packages/react/components/input/Input.tsx
@@ -44,7 +44,7 @@ interface IconWrapper {
  * @param maxLength {number} Textarea max length
  * @param securityGauge {boolean} add security gauge for input type password
  * @param validationRules {IValidationRules} Textarea max length
-
+ * @param readOnly {boolean} Read only input
  * - -------------------------- WEB PROPERTIES -------------------------------
  * @param loading {boolean} Loading input
  * @param value {string} Value for Input

--- a/packages/react/components/input/InputProps.ts
+++ b/packages/react/components/input/InputProps.ts
@@ -113,6 +113,7 @@ export interface InputProps extends Accessibility, Dev, CommonProps {
   securityGauge?: boolean
   validationRules?: IValidationRules
   required?: boolean
+  readOnly?: boolean
 }
 
 export interface ILengthVerify {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a static, non-editable input element to display preset information, enhancing the interface with read-only functionality.
  - Activated a spacing component to maintain a consistent, balanced layout.
  - Enabled an option for input fields to be rendered as non-editable, expanding control over user-interaction dynamics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->