### PR TITLE
Accordion header arrow padding to avoid overlap

### DIFF
--- a/packages/styles/framework/src/components/_accordion.scss
+++ b/packages/styles/framework/src/components/_accordion.scss
@@ -45,8 +45,8 @@
     }
 
     .accordion-header:after {
-      max-width: 15px;
-      max-height: 15px;
+      max-width: $arrow-size;
+      max-height: $arrow-size;
       position: absolute;
       margin-top: 0;
       right: 20px;
@@ -93,7 +93,7 @@
       position: relative;
       height: auto;
       cursor: pointer;
-      padding: $spacing-4;
+      padding: $spacing-4 calc($spacing-4 * 2 + $arrow-size) $spacing-4 $spacing-4;
 
       &.is-grouped {
         > *:first-child {

--- a/packages/styles/framework/src/utilities/_initial-variables.scss
+++ b/packages/styles/framework/src/utilities/_initial-variables.scss
@@ -6,3 +6,5 @@ $hoverSelector: "&:hover:not([disabled]):not([aria-disabled=true])";
 $radius-small: 4px !default;
 $radius: 8px !default;
 
+// Arrow size
+$arrow-size: 15px;

--- a/packages/styles/framework/src/utilities/mixins/_arrow.scss
+++ b/packages/styles/framework/src/utilities/mixins/_arrow.scss
@@ -1,3 +1,5 @@
+@import "./../initial-variables";
+
 @mixin arrow( $direction: 'down') {
   background-color: currentColor;
   content: "";
@@ -11,9 +13,9 @@
     rotate: 270deg;
   }
 
-  min-width: 15px;
-  min-height: 15px;
-  mask-size: 15px;
+  min-width: $arrow-size;
+  min-height: $arrow-size;
+  mask-size: $arrow-size;
   position: absolute;
   display: inline-block;
 }


### PR DESCRIPTION
# Issue

Accordion header can be full width of the accordion component, overlapping the accordion's arrow :
<img width="786" alt="image" src="https://github.com/user-attachments/assets/84d9a1d2-7060-42bb-bd0d-636e42271f9f" />

# Solution

`padding-right` on accordion header component to be at least `the size of the arrow` + `padding` 
<img width="786" alt="image" src="https://github.com/user-attachments/assets/3f96f309-1d5c-43e8-ada3-7c1b05abf809" />
