### PR TITLE
Add blank props if href & blank

### DIFF
--- a/packages/react/components/box/Box.tsx
+++ b/packages/react/components/box/Box.tsx
@@ -24,6 +24,7 @@ import { BoxProps, BoxRef } from './BoxProps'
  * - -------------------------- WEB PROPERTIES -------------------------------
  * @param className {string} Additionnal css classes
  * @param fullheight
+ * @param blank If href && blank : target Blank
  * @param others
  */
 const Box = React.forwardRef<BoxRef, BoxProps>(
@@ -36,6 +37,7 @@ const Box = React.forwardRef<BoxRef, BoxProps>(
       onClick,
       skeleton,
       href,
+      blank,
       backgroundColor,
       highlighted,
       shadowless,
@@ -80,6 +82,9 @@ const Box = React.forwardRef<BoxRef, BoxProps>(
         id={id}
         style={onClick && { ...hoverStyle }}
         href={href}
+        {...(href && blank && {
+          target: '_blank',
+        })}
         onClick={(e) => {
           // eslint-disable-next-line no-unused-expressions
           onClick?.(e)

--- a/packages/react/components/box/BoxProps.ts
+++ b/packages/react/components/box/BoxProps.ts
@@ -21,6 +21,7 @@ export interface BoxProps extends BackgroundProps, Clickable, Fullheight, Access
   flat?: boolean
   active?: boolean
   inverted?: boolean
+  blank?: boolean
 }
 
 export type BoxRef = HTMLDivElement


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for opening links in a new tab/window via a new option on the Box component. When enabled with a link, the link will open in a new browser tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->