### PR TITLE
Fix autocomplete

### DIFF
--- a/examples/react-template/screens/Autocomplete.tsx
+++ b/examples/react-template/screens/Autocomplete.tsx
@@ -125,6 +125,24 @@ export const AutoCompleteScreen = (): JSX.Element => {
           </ButtonList>
         </Column>
       </Columns>
+      <AutoComplete
+        iconNameLeft={IconName.INFOS_CIRCLE}
+        displayMenu={false}
+        value={value}
+        data={data}
+        absoluteMenu
+        fullwidthMenu
+        disabled={status}
+        placeholder='Autocomplete'
+        onItemSelected={(e) => {
+          setValue(e.value || '')
+          console.log('onItemSelected : ', e.value)
+        }}
+        onChange={onChange}
+        onIconClick={onIconClick}
+        onFocus={(e) => console.log('FOCUS : ', e)}
+        onBlur={(e) => console.log('BLUR : ', e)}
+      />
     </Section>
   )
 }

--- a/examples/react-template/screens/Autocomplete.tsx
+++ b/examples/react-template/screens/Autocomplete.tsx
@@ -125,24 +125,6 @@ export const AutoCompleteScreen = (): JSX.Element => {
           </ButtonList>
         </Column>
       </Columns>
-      <AutoComplete
-        iconNameLeft={IconName.INFOS_CIRCLE}
-        displayMenu={false}
-        value={value}
-        data={data}
-        absoluteMenu
-        fullwidthMenu
-        disabled={status}
-        placeholder='Autocomplete'
-        onItemSelected={(e) => {
-          setValue(e.value || '')
-          console.log('onItemSelected : ', e.value)
-        }}
-        onChange={onChange}
-        onIconClick={onIconClick}
-        onFocus={(e) => console.log('FOCUS : ', e)}
-        onBlur={(e) => console.log('BLUR : ', e)}
-      />
     </Section>
   )
 }

--- a/packages/react/components/autocomplete/AutoComplete.tsx
+++ b/packages/react/components/autocomplete/AutoComplete.tsx
@@ -177,7 +177,7 @@ const AutoCompleteRef = <T extends string | Item<unknown> = string>(
         }}
         onIconClick={onIconClick}
         loading={loading}
-        {...others}
+        {...{ onKeyDown: (e: React.KeyboardEvent) => e.key === 'Enter' && e.preventDefault(), ...others }}
       />
 
       {isAutocompleteMenuVisible && (


### PR DESCRIPTION
add preventDefault to onKeyDown att

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Prevented the default action when pressing the Enter key in the autocomplete input, improving user experience when interacting with suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->