### PR TITLE
Fix tests + type=tel on OTP for all case

### DIFF
--- a/packages/react/components/autocomplete/test/Autocomplete.test.tsx
+++ b/packages/react/components/autocomplete/test/Autocomplete.test.tsx
@@ -87,7 +87,7 @@ describe('AutoComplete', () => {
   it('input should  have classname autocomplete', () => {
     render(<AutoComplete data={testItems} />)
     const input = screen.getByRole('textbox')
-    expect(input.parentNode?.parentNode).toHaveClass('autocomplete-input')
+    expect(input.parentNode?.parentNode).toHaveClass('field')
   })
 
   it('input should  default status class', () => {

--- a/packages/react/components/otp/Otp.tsx
+++ b/packages/react/components/otp/Otp.tsx
@@ -5,7 +5,7 @@ import { TypographyColor } from '@/objects/Typography'
 import { is } from '@/services/classify'
 import { inputTitle } from '@trilogy-ds/locales/lib/otp.json'
 import clsx from 'clsx'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState, useMemo } from 'react'
 import { ComponentName } from '../enumsComponentsName'
 import { OtpProps, OtpRef } from './OtpProps'
 
@@ -180,7 +180,7 @@ const Otp = React.forwardRef<OtpRef, OtpProps>(
             <input
               aria-disabled={disabled}
               key={idx}
-              type='text'
+              type={'tel'} // To display the numeric keypad and avoid showing the plus/minus arrows.
               inputMode='numeric'
               autoComplete='one-time-code'
               autoFocus={idx === 0 && autoFocus}

--- a/packages/react/components/otp/test/Otp.test.tsx
+++ b/packages/react/components/otp/test/Otp.test.tsx
@@ -5,13 +5,12 @@ import Otp from '../Otp'
 describe('Otp', () => {
   const defaultProps = {
     code: '',
-    codeSize: 6,
+    length: 6,
     disabled: false,
     error: false,
     onCompleted: jest.fn(),
     onChange: jest.fn(),
     onFocus: jest.fn(),
-    autoFocus: true,
   }
 
   it('renders without error', () => {


### PR DESCRIPTION
I set the type to 'tel to display the numeric keypad and avoid showing the plus/minus arrows.

With `type=numeric` there is a bug with Safari on iOS (see : https://github.com/chakra-ui/chakra-ui/issues/4095)
With `type=text` mobile show the default keyboard instead the numeric keyboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated OTP input fields to use a numeric keypad on mobile devices for easier entry.
- **Tests**
  - Adjusted test expectations for the AutoComplete component's input container class.
  - Updated OTP component test setup to use the `length` property and removed `autoFocus` from defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->