### PR TITLE
fix reset classes on Anchor element

### DIFF
--- a/packages/styles/framework/src/base/_reset.scss
+++ b/packages/styles/framework/src/base/_reset.scss
@@ -41,7 +41,7 @@
         margin-bottom: 10px;
     }
 
-  a {
+  a.link {
     color: getColor('font');
     cursor: pointer;
     text-decoration: none;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated link styling to apply only to anchor elements with the "link" class, instead of all anchor elements globally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->