### PR TITLE
delete prop linkblank

### DIFF
--- a/packages/react/components/timeline/content/TimelineContent.tsx
+++ b/packages/react/components/timeline/content/TimelineContent.tsx
@@ -17,10 +17,9 @@ import { TimelineContentRef, TimelineContentWebProps } from './TimelineContentPr
  * - -------------------------- WEB PROPERTIES -------------------------------
  * @param className {string} Additional CSS Classes
  * @param id {string} Custom id
- * @param linkBlank {boolean} add target blank on link
  */
 const TimelineContent = React.forwardRef<TimelineContentRef, TimelineContentWebProps>(
-  ({ children, className, id, heading, content, linkLabel, linkTo, linkBlank, ...others }, ref): JSX.Element => {
+  ({ children, className, id, heading, content, linkLabel, linkTo, ...others }, ref): JSX.Element => {
     const { styled } = useTrilogyContext()
     const classes = hashClass(styled, clsx('timeline-content', className))
 
@@ -40,11 +39,7 @@ const TimelineContent = React.forwardRef<TimelineContentRef, TimelineContentWebP
             {content}
           </Text>
         )}
-        {linkTo && linkLabel && (
-          <Link href={linkTo} blank={linkBlank}>
-            {linkLabel}
-          </Link>
-        )}
+        {linkTo && linkLabel && <Link href={linkTo}>{linkLabel}</Link>}
       </div>
     )
   },

--- a/packages/react/components/timeline/content/TimelineContentProps.ts
+++ b/packages/react/components/timeline/content/TimelineContentProps.ts
@@ -15,9 +15,7 @@ export interface TimelineContentProps {
 /**
  * Timeline Content Web Interface
  */
-export interface TimelineContentWebProps extends TimelineContentProps, CommonProps {
-  linkBlank?: boolean
-}
+export interface TimelineContentWebProps extends TimelineContentProps, CommonProps {}
 
 export type TimelineContentRef = HTMLDivElement
 export type TimelineContentNativeRef = View


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed support for opening timeline links in a new tab from the timeline content component. All timeline links now open in the same tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->