### PR TITLE
Adding a11y in utilities/_pre scss file

### DIFF
--- a/packages/styles/framework/src/utilities/_pre.scss
+++ b/packages/styles/framework/src/utilities/_pre.scss
@@ -1,6 +1,8 @@
 @charset "utf-8";
-/* Variables can be redefined*/
+/* Variables can be redefined */
 
 @import 'initial-variables';
 @import '../theming/_all';
 @import 'derived-variables';
+@import 'a11y';
+


### PR DESCRIPTION
a11y is missing in utilities/_pre file used to create 'complex' themes with the pre/post flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved formatting for better readability in stylesheets.

- **Chores**
  - Added accessibility-related styles to enhance support for accessible design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->