### PR TITLE
🐛 Remove text-align: left, mobile-only box-content

### DIFF
--- a/packages/styles/framework/src/components/_box.scss
+++ b/packages/styles/framework/src/components/_box.scss
@@ -143,10 +143,6 @@ a.box {
       border-bottom-right-radius: var(--radius);
     }
 
-    @include mobile {
-      text-align: left;
-    }
-
     > .is-unboxed {
       margin-left: calc(var(--padding-box) * -1);
       margin-right: calc(var(--padding-box) * -1);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated mobile styles for box content by removing the explicit left text alignment on mobile devices. Text alignment on mobile will now follow inherited or default styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->