### PR TITLE
fix(modal): add bottom safe area inset for Android edge-to-edge (API …

### DIFF
--- a/packages/react/components/modal/Modal.native.tsx
+++ b/packages/react/components/modal/Modal.native.tsx
@@ -13,6 +13,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated'
 import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler'
 import { Column, Columns } from '../columns'
@@ -134,6 +135,8 @@ const Modal = React.forwardRef<ModalNativeRef, ModalProps>(
       backgroundColor: `rgba(0, 0, 0, ${backdropOpacity.value})`,
     }))
 
+    const { bottom: bottomInset } = useSafeAreaInsets()
+
     return (
       <ModalContext.Provider value={{ scrollViewRef, handleOnScroll, isFooter, setIsFooter }}>
         {trigger}
@@ -156,7 +159,7 @@ const Modal = React.forwardRef<ModalNativeRef, ModalProps>(
             </Animated.View>
             <Animated.View
               ref={ref}
-              style={[styles.body, { backgroundColor: getColorStyle(TrilogyColor.BACKGROUND) }, animatedStyle]}
+              style={[styles.body, { backgroundColor: getColorStyle(TrilogyColor.BACKGROUND) }, animatedStyle, isAndroid ? { paddingBottom: bottomInset } : {}]}
               {...others}
             >
               <GestureDetector gesture={panGesture}>

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,7 +42,8 @@
     "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
-    "react-native-reanimated": ">=2.15.0 <4.0.0"
+    "react-native-reanimated": ">=2.15.0 <4.0.0",
+    "react-native-safe-area-context": ">=3.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
Android 15+ enforces edge-to-edge — the navigation bar becomes transparent and content draws behind it. RNModal with statusBarTranslucent=true creates a dialog window that is also edge-to-edge, causing modal content to be hidden behind the nav bar.

Fix: inject useSafeAreaInsets() and apply paddingBottom: bottomInset to the modal body on Android only. On older Android (< 15), insets.bottom = 0 so there is no visual change.

Also adds react-native-safe-area-context as a peer dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modal component now properly accommodates safe-area insets on Android devices for improved layout consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->