### PR TITLE
🐛 fix(Price): align overline text with Price align prop

### DIFF
--- a/packages/react/components/price/Price.native.tsx
+++ b/packages/react/components/price/Price.native.tsx
@@ -222,6 +222,10 @@ const Price = React.forwardRef<PriceNativeRef, PriceProps>(
         paddingLeft: 4,
         marginBottom: -3,
         color: color,
+        textAlign:
+          (align === Alignable.ALIGNED_CENTER && 'center') ||
+          (align === Alignable.ALIGNED_END && 'right') ||
+          'left',
       },
       tag: {
         paddingTop:


### PR DESCRIPTION
## Problem

The Price component's `overline` (suptitle) text does not respect the `align` prop on React Native. It is always left-aligned regardless of the `align` value passed to the component.

## Fix

Added `textAlign` to the suptitle style in `Price.native.tsx`, mapping:
- `Alignable.ALIGNED_CENTER` → `'center'`
- `Alignable.ALIGNED_END` → `'right'`
- default → `'left'`

This makes the overline text alignment consistent with the rest of the Price component.