### PR TITLE
Update height components

### DIFF
--- a/packages/styles/framework/src/components/_button.scss
+++ b/packages/styles/framework/src/components/_button.scss
@@ -33,6 +33,7 @@ $button-border-width: 2px !default;
   padding: 0 $spacing-4;
   text-decoration: inherit;
   font-weight: $weight-semibold;
+  height: $size-inputs;
 
   @include mobile {
     width: 100%;

--- a/packages/styles/framework/src/components/_otp.scss
+++ b/packages/styles/framework/src/components/_otp.scss
@@ -9,7 +9,7 @@
     border-radius: var(--radius-small);
     background: transparent;
     width: 33px;
-    height: 40px;
+    height: 48px;
     margin: 4px 4px 0 4px;
     text-align: center;
     color: getColor('main');

--- a/packages/styles/framework/src/utilities/mixins/_mixins.scss
+++ b/packages/styles/framework/src/utilities/mixins/_mixins.scss
@@ -24,7 +24,7 @@
 // import sass bulma
 @mixin input {
   @include control;
-  height: 56px;
+  height: $size-inputs;
   background-color: getColor('background');
   border: var(--border);
   color: getColor('font');

--- a/packages/styles/framework/src/utilities/variables/_index.scss
+++ b/packages/styles/framework/src/utilities/variables/_index.scss
@@ -4,4 +4,4 @@
 @import "responsiveness";
 @import "shadow";
 @import "zindex";
-@import "sizes"
+@import "sizes";

--- a/packages/styles/framework/src/utilities/variables/_index.scss
+++ b/packages/styles/framework/src/utilities/variables/_index.scss
@@ -4,3 +4,4 @@
 @import "responsiveness";
 @import "shadow";
 @import "zindex";
+@import "sizes"

--- a/packages/styles/framework/src/utilities/variables/_sizes.scss
+++ b/packages/styles/framework/src/utilities/variables/_sizes.scss
@@ -1,0 +1,1 @@
+$size-inputs: 48px;


### PR DESCRIPTION
- button, inputs, select, otp, pickers: 48px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized the height of buttons and input-related controls to a shared sizing value.
  * OTP input boxes now display at a consistent, larger height.
* **New Features**
  * Introduced a reusable sizing token for input controls to keep form elements aligned across the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->