### PR TITLE
Add brand color

### DIFF
--- a/packages/react/objects/facets/Color.tsx
+++ b/packages/react/objects/facets/Color.tsx
@@ -7,6 +7,8 @@ import { DEFAULT_TRILOGY_COLORS } from './defaultColors'
  */
 export enum TrilogyColor {
   BACKGROUND = 'WHITE',
+  BRAND = 'BRAND',
+  BRAND_FADE = 'BRAND_FADE',
   MAIN = 'MAIN',
   MAIN_FADE = 'MAIN_FADE',
   ACCENT = 'ACCENT',
@@ -34,7 +36,10 @@ export type TrilogyColorValues = `${TrilogyColor}`
 /**
  * Trilogy color values
  */
-export const colors: Record<TrilogyColor, string[]> = DEFAULT_TRILOGY_COLORS as unknown as Record<TrilogyColor, string[]>
+export const colors: Record<TrilogyColor, string[]> = DEFAULT_TRILOGY_COLORS as unknown as Record<
+  TrilogyColor,
+  string[]
+>
 
 /**
  * Returns color's className depending on Trilogy Color

--- a/packages/react/objects/facets/defaultColors.ts
+++ b/packages/react/objects/facets/defaultColors.ts
@@ -1,9 +1,14 @@
 export const DEFAULT_TRILOGY_COLORS = {
   WHITE: ['#fff', 'white', 'main'],
+
   MAIN: ['#3d5d7e', 'main', 'white'],
   MAIN_FADE: ['#BBC6CD', 'main-fade', 'white'],
+
   ACCENT: ['#da641b', 'accent', 'white'],
   ACCENT_FADE: ['#faebe3', 'accent-fade', 'white'],
+
+  BRAND: ['#ccd5f8', 'brand', 'white'],
+  BRAND_FADE: ['#e8eef8', 'brand-fade', 'white'],
 
   FONT: ['#3d5d7e', 'main', 'white'],
   FONT_PLACEHOLDER: ['#687a87', 'font-placeholder', 'white'],

--- a/packages/styles/framework/src/utilities/variables/_color.scss
+++ b/packages/styles/framework/src/utilities/variables/_color.scss
@@ -11,6 +11,8 @@ $suffix: '';
  */
 $colors: (
   'background': [#fff, 'white', 'main'],
+  'brand': [#ccd5f8, 'brand', 'white'],
+  'brand-fade': [#e8eef8, 'brand-fade', 'white'],
   'stroke':[ #727272, 'stroke', 'white' ],
   'stroke-fade':[ #cadbe8, 'stroke-fade', 'white' ],
   'transparent': ['transparent', 'transparent', 'transparent'],
@@ -35,6 +37,7 @@ $colors: (
 ) !default;
 
 $fade-colors: (
+  'brand': 'brand-fade',
   'main': 'main-fade',
   'success': 'success-fade',
   'info':'info-fade',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new **brand** and **brand-fade** color variants for styling across the UI.
  * Introduced matching fade behavior so **brand** automatically maps to **brand-fade** for consistent transitions.
  * Extended the available color set so these new variants are available for use wherever selectable color facets are defined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->