### PR TITLE
perf(react-native): memoize StyleSheet styles and apply mcare native …

### DIFF
--- a/packages/react/components/accordion/Accordion.native.tsx
+++ b/packages/react/components/accordion/Accordion.native.tsx
@@ -1,7 +1,8 @@
 import { AccordionNativeRef, AccordionProps } from '@/components/accordion/AccordionProps'
 import { ComponentName } from '@/components/enumsComponentsName'
 import * as React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 
 /**
  * Accordion Component
@@ -11,7 +12,7 @@ import { StyleSheet, View } from 'react-native'
  * @param id {string} Custom id attribute
  */
 const Accordion = React.forwardRef<AccordionNativeRef, AccordionProps>(({ testId, ...others }, ref): JSX.Element => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     accordion: {
       width: '100%',
       minHeight: 10,

--- a/packages/react/components/accordion/item/AccordionItem.native.tsx
+++ b/packages/react/components/accordion/item/AccordionItem.native.tsx
@@ -4,7 +4,8 @@ import { IconName } from '@/components/icon/IconNameEnum'
 import { Spacer, SpacerSize } from '@/components/spacer'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import React, { isValidElement, useEffect, useRef, useState } from 'react'
-import { Animated, Easing, StyleSheet, TouchableWithoutFeedback, View } from 'react-native'
+import { Animated, Easing, TouchableWithoutFeedback, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { AccordionItemNativeRef, AccordionItemProps } from './AccordionItemProps'
 
 interface AccordionChild {
@@ -32,7 +33,7 @@ const AccordionItem = React.forwardRef<AccordionItemNativeRef, AccordionItemProp
       body: undefined,
     })
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       item: {
         width: '100%',
         padding: 5,

--- a/packages/react/components/accordion/item/body/AccordionBody.native.tsx
+++ b/packages/react/components/accordion/item/body/AccordionBody.native.tsx
@@ -1,6 +1,7 @@
 import { ComponentName } from '@/components/enumsComponentsName'
 import * as React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { AccordionBodyNativeRef, AccordionBodyProps } from './AccordionBodyProps'
 
 /**
@@ -11,7 +12,7 @@ import { AccordionBodyNativeRef, AccordionBodyProps } from './AccordionBodyProps
  */
 const AccordionBody = React.forwardRef<AccordionBodyNativeRef, AccordionBodyProps>(
   ({ children, testId, ...others }, ref): JSX.Element => {
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       accordionBody: {},
     })
 

--- a/packages/react/components/accordion/item/header/AccordionHeader.native.tsx
+++ b/packages/react/components/accordion/item/header/AccordionHeader.native.tsx
@@ -1,6 +1,7 @@
 import { ComponentName } from '@/components/enumsComponentsName'
 import * as React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { AccordionHeaderNativeRef, AccordionHeaderProps } from './AccordionHeaderProps'
 
 /**
@@ -11,7 +12,7 @@ import { AccordionHeaderNativeRef, AccordionHeaderProps } from './AccordionHeade
  */
 const AccordionHeader = React.forwardRef<AccordionHeaderNativeRef, AccordionHeaderProps>(
   ({ children }, ref): JSX.Element => {
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       header: {
         maxWidth: '95%',
         minWidth: '95%',

--- a/packages/react/components/alert/Alert.native.tsx
+++ b/packages/react/components/alert/Alert.native.tsx
@@ -8,7 +8,8 @@ import { View } from '@/components/view'
 import { Alignable, TrilogyColor, TypographyBold } from '@/objects'
 import { getStatusIconName, getStatusStyle } from '@/objects/facets/Status'
 import * as React from 'react'
-import { StyleSheet, TouchableOpacity } from 'react-native'
+import { TouchableOpacity } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import LibToast from 'react-native-toast-message'
 import { Row, Rows } from '../rows'
 import { AlertNativeRef, AlertProps, ToasterAlertPosition, ToasterStatusProps } from './AlertProps'
@@ -48,7 +49,7 @@ const Alert = React.forwardRef<AlertNativeRef, AlertProps>(
     const { color, backgroundColor } = getStatusStyle(status)
     let alertView: JSX.Element
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       container: {
         width: '100%',
         paddingTop: 12,
@@ -134,7 +135,7 @@ export const ToasterAlert: React.FC<{ props: ToasterStatusProps }> = ({ props })
   const { title, description, iconName, status, closable, onClick } = props
   const { color, backgroundColor } = getStatusStyle(status)
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     toaster: {
       padding: 24,
     },

--- a/packages/react/components/autocomplete/menu/AutoCompleteMenu.native.tsx
+++ b/packages/react/components/autocomplete/menu/AutoCompleteMenu.native.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
-import { FlatList, StyleSheet } from 'react-native'
+import { FlatList } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { TrilogyColor, getColorStyle } from '@/objects'
 import AutoCompleteItemNative from '@/components/autocomplete/item/AutoCompleteIem.native'
 import { AutoCompleteMenuProps } from './AutoCompleteMenuProps'
@@ -13,7 +14,7 @@ import { AutoCompleteMenuProps } from './AutoCompleteMenuProps'
  * @param handleSelectItem {Function} Callback when selecting an item
  */
 const AutoCompleteMenuNative = ({ suggestions, handleSelectItem }: AutoCompleteMenuProps): JSX.Element => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     list: {
       marginTop: 6,
       marginBottom: 6,

--- a/packages/react/components/badge/Badge.native.tsx
+++ b/packages/react/components/badge/Badge.native.tsx
@@ -5,7 +5,8 @@ import { Icon, IconColor, IconName, IconSize } from '@/components/icon'
 import { StatusState } from '@/objects'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import React from 'react'
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { Text, TouchableOpacity, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 
 /**
  * Badge Component
@@ -24,7 +25,7 @@ const Badge = React.forwardRef<BadgeNativeRef, BadgeProps>(
     const badgeColor = getColorStyle(variant || TrilogyColor.MAIN)
     const textColor = getColorStyle(TrilogyColor.BACKGROUND)
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       container: {
         flexDirection: 'row',
       },

--- a/packages/react/components/box/Box.native.tsx
+++ b/packages/react/components/box/Box.native.tsx
@@ -4,7 +4,8 @@ import { ComponentName } from '@/components/enumsComponentsName'
 import { StatesContext } from '@/context/providerStates'
 import { getColorStyle, TrilogyColor, TrilogyColorValues } from '@/objects/facets/Color'
 import React, { useState } from 'react'
-import { ImageBackground, Platform, StyleSheet, TouchableOpacity, View } from 'react-native'
+import { ImageBackground, Platform, TouchableOpacity, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { Skeleton } from '../skeleton'
 
 /**
@@ -50,7 +51,7 @@ const Box = React.forwardRef<BoxNativeRef, BoxProps>(
     const [header, setHeader] = useState<boolean>(false)
 
     const boxRadius = 6
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       box: {
         width: '100%',
         backgroundColor: backgroundColor ? getColorStyle(backgroundColor) : colorBgc,

--- a/packages/react/components/box/content/BoxContent.native.tsx
+++ b/packages/react/components/box/content/BoxContent.native.tsx
@@ -3,7 +3,8 @@ import { BoxContext } from '@/components/box/context/boxContext'
 import { ComponentName } from '@/components/enumsComponentsName'
 import { getColorStyle } from '@/objects/facets/Color'
 import * as React from 'react'
-import { ImageBackground, StyleSheet, Text, View } from 'react-native'
+import { ImageBackground, Text, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 
 /**
  * Box Content
@@ -17,7 +18,7 @@ const BoxContent = React.forwardRef<BoxContentNativeRef, BoxContentProps>(
   ({ children, backgroundColor, backgroundSrc, testId, ...others }, ref): JSX.Element => {
     const { fullHeight, highlighted, header, numberOfContent, setNumberOfContent } = React.useContext(BoxContext)
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       boxContent: {
         padding: 16,
         backgroundColor: (backgroundColor && getColorStyle(backgroundColor)) || 'transparent',

--- a/packages/react/components/box/footer/BoxFooter.native.tsx
+++ b/packages/react/components/box/footer/BoxFooter.native.tsx
@@ -1,7 +1,8 @@
 import { ComponentName } from '@/components/enumsComponentsName'
 import { getColorStyle } from '@/objects'
 import * as React from 'react'
-import { StyleSheet, Text, View } from 'react-native'
+import { Text, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { BoxContext } from '../context/boxContext'
 import { BoxFooterNativeRef, BoxFooterProps } from './BoxFooterProps'
 
@@ -17,7 +18,7 @@ const BoxFooter = React.forwardRef<BoxFooterNativeRef, BoxFooterProps>(
     const boxRadius = 6
     const { highlighted } = React.useContext(BoxContext)
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       boxFooter: {
         padding: 12,
         justifyContent: 'center',

--- a/packages/react/components/box/header/BoxHeader.native.tsx
+++ b/packages/react/components/box/header/BoxHeader.native.tsx
@@ -3,7 +3,8 @@ import { StatesContext } from '@/context/providerStates'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import * as React from 'react'
 import { useContext } from 'react'
-import { StyleSheet, Text, View } from 'react-native'
+import { Text, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { BoxContext } from '../context/boxContext'
 import { BoxHeaderNativeRef, BoxHeaderProps } from './BoxHeaderProps'
 
@@ -26,7 +27,7 @@ const BoxHeader = React.forwardRef<BoxHeaderNativeRef, BoxHeaderProps>(
     const headerBgc = variant ? getColorStyle(variant) : getColorStyle(TrilogyColor.MAIN)
     const textColor = getColorStyle(TrilogyColor.BACKGROUND)
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       boxHeader: {
         width: '100%',
         backgroundColor: headerBgc,

--- a/packages/react/components/box/item/BoxItem.native.tsx
+++ b/packages/react/components/box/item/BoxItem.native.tsx
@@ -1,6 +1,7 @@
 import { ComponentName } from '@/components/enumsComponentsName'
 import * as React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { BoxItemNativeRef, BoxItemProps } from './BoxItemProps'
 
 /**
@@ -12,7 +13,7 @@ import { BoxItemNativeRef, BoxItemProps } from './BoxItemProps'
  */
 const BoxItem = React.forwardRef<BoxItemNativeRef, BoxItemProps>(({ children, size, testId, ...others }, ref): JSX.Element => {
   const height = Number(size) || 48
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     boxItem: {
       height: height,
       alignItems: 'center',

--- a/packages/react/components/box/table-container/BoxTableContainer.native.tsx
+++ b/packages/react/components/box/table-container/BoxTableContainer.native.tsx
@@ -1,6 +1,7 @@
 import { ComponentName } from '@/components/enumsComponentsName'
 import * as React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { BoxTableContainerNativeRef, BoxTableContainerProps } from './BoxTableContainerProps'
 
 /**
@@ -10,7 +11,7 @@ import { BoxTableContainerNativeRef, BoxTableContainerProps } from './BoxTableCo
  */
 const boxTableContainer = React.forwardRef<BoxTableContainerNativeRef, BoxTableContainerProps>(
   ({ children, testId, ...others }, ref): JSX.Element => {
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       boxTableContainer: {},
     })
 

--- a/packages/react/components/button/Button.native.tsx
+++ b/packages/react/components/button/Button.native.tsx
@@ -6,7 +6,8 @@ import { getButtonColorStyle, getColorStyle, TrilogyColor } from '@/objects/face
 import { getLoadingClassName } from '@/objects/facets/Loadable'
 import { getVariantClassName } from '@/objects/facets/Variant'
 import * as React from 'react'
-import { ActivityIndicator, StyleSheet, Text, TouchableOpacity } from 'react-native'
+import { ActivityIndicator, Text, TouchableOpacity } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { ButtonVariant } from './ButtonEnum'
 import { ButtonNativeRef, ButtonProps } from './ButtonProps'
 
@@ -58,7 +59,7 @@ const Button = React.forwardRef<ButtonNativeRef, ButtonProps>(
         ? TrilogyColor.INFO_FADE
         : TrilogyColor.BACKGROUND
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       button: {
         maxWidth: '100%',
         minWidth: '100%',

--- a/packages/react/components/card/Card.native.tsx
+++ b/packages/react/components/card/Card.native.tsx
@@ -2,7 +2,8 @@ import { ComponentName } from '@/components/enumsComponentsName'
 import { StatesContext } from '@/context/providerStates'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import React, { createContext, PropsWithChildren } from 'react'
-import { Platform, StyleSheet, TouchableOpacity, View } from 'react-native'
+import { Platform, TouchableOpacity, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { Skeleton } from '../skeleton'
 import { CardNativeRef, CardProps } from './CardProps'
 
@@ -34,7 +35,7 @@ const Card = React.forwardRef<CardNativeRef, CardProps>(
   ): JSX.Element => {
     const borderColor = getColorStyle(TrilogyColor.STROKE_FADE)
     const cardRadius = 6
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       card: {
         width: '100%',
         minHeight: 100,

--- a/packages/react/components/card/content/CardContent.native.tsx
+++ b/packages/react/components/card/content/CardContent.native.tsx
@@ -1,7 +1,8 @@
 import { CardContext } from '@/components/card/Card.native'
 import { ComponentName } from '@/components/enumsComponentsName'
 import React, { useContext } from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { CardContentNativeRef, CardContentProps } from './CardContentProps'
 
 /**
@@ -14,7 +15,7 @@ const CardContent = React.forwardRef<CardContentNativeRef, CardContentProps>(
   ({ children, testId, ...others }, ref): JSX.Element => {
     const cardContextValues = useContext(CardContext)
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       card: {
         padding: 16,
         minHeight: 10,

--- a/packages/react/components/card/image/CardImage.native.tsx
+++ b/packages/react/components/card/image/CardImage.native.tsx
@@ -1,7 +1,8 @@
 import { CardContext } from '@/components/card/Card.native'
 import { ComponentName } from '@/components/enumsComponentsName'
 import React, { useContext, useEffect, useState } from 'react'
-import { Image, StyleSheet, TouchableOpacity, View } from 'react-native'
+import { Image, TouchableOpacity, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { CardImageNativeRef, CardImageProps } from './CardImageProps'
 
 /**
@@ -20,11 +21,10 @@ const CardImage = React.forwardRef<CardImageNativeRef, CardImageProps>(
     const maxSize = horizontal ? '50%' : '100%'
     const [ratio, setRatio] = useState(1)
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       cardImage: {
         width: size ? `${size}0%` : maxSize,
         aspectRatio: horizontal ? undefined : ratio,
-        resizeMode: contain ? 'contain' : 'cover',
         alignSelf: contain ? 'flex-end' : 'auto',
         marginBottom: 0,
         height: horizontal ? 'auto' : undefined,
@@ -48,6 +48,7 @@ const CardImage = React.forwardRef<CardImageNativeRef, CardImageProps>(
     const image = (
       <Image
         ref={ref}
+        resizeMode={contain ? 'contain' : 'cover'}
         accessibilityLabel={alt}
         style={styles.cardImage}
         source={typeof src === 'number' ? src : { uri: src }}

--- a/packages/react/components/checkbox/Checkbox.native.tsx
+++ b/packages/react/components/checkbox/Checkbox.native.tsx
@@ -4,7 +4,8 @@ import { IconName } from '@/components/icon/IconNameEnum'
 import { Text } from '@/components/text'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import React, { useEffect, useState } from 'react'
-import { StyleSheet, TouchableOpacity } from 'react-native'
+import { TouchableOpacity } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { CheckboxNativeRef, CheckboxProps } from './CheckboxProps'
 
 /**
@@ -26,7 +27,7 @@ const Checkbox = React.forwardRef<CheckboxNativeRef, CheckboxProps>(
       setChecked(checked || false)
     }, [checked])
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       container: {
         flexDirection: 'row',
         justifyContent: 'flex-start',

--- a/packages/react/components/checkbox/list/CheckboxList.native.tsx
+++ b/packages/react/components/checkbox/list/CheckboxList.native.tsx
@@ -5,7 +5,8 @@ import { SpacerSize } from '@/components/spacer'
 import { Text } from '@/components/text'
 import * as React from 'react'
 import type { CheckboxListNativeRef, CheckboxListProps } from './CheckboxListProps'
-import { StyleSheet } from 'react-native'
+import {  } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { isRequiredChild } from '@/helpers/require'
 import { TypographyColor } from '@/objects/Typography'
 
@@ -24,7 +25,7 @@ const SPACING_MATRIX: SpacingMatrix = [
  * @param label {string} Label for the CheckboxList group
  */
 const CheckboxList = React.forwardRef<CheckboxListNativeRef, CheckboxListProps>(({ children, label }, ref): JSX.Element => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     label: {
       marginBottom: 8,
     },

--- a/packages/react/components/checkbox/tiles/CheckboxTiles.native.tsx
+++ b/packages/react/components/checkbox/tiles/CheckboxTiles.native.tsx
@@ -2,7 +2,8 @@ import { ComponentName } from '@/components/enumsComponentsName'
 import { SpacerSize } from '@/components/spacer'
 import { getAlignStyle } from '@/objects/facets/Alignable'
 import React, { ReactNode, RefObject, useCallback, useMemo } from 'react'
-import { FlatList, StyleSheet, View } from 'react-native'
+import { FlatList, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { CheckboxTilesNativeRef, CheckboxTilesProps } from './CheckboxTilesProps'
 import { CheckboxTilesContext } from './context'
 
@@ -27,7 +28,7 @@ const CheckboxTiles = React.forwardRef<CheckboxTilesNativeRef, CheckboxTilesProp
       return numberCols.mobile || numberCols.tablet
     }, [numberCols])
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       container: {
         flexDirection: 'row',
         flexWrap: 'wrap',

--- a/packages/react/components/checkbox/tiles/tile/CheckboxTile.native.tsx
+++ b/packages/react/components/checkbox/tiles/tile/CheckboxTile.native.tsx
@@ -6,7 +6,8 @@ import { Text, TextLevels } from '@/components/text'
 import { View } from '@/components/view'
 import { getColorStyle, TrilogyColor, TypographyAlign, TypographyBold, VariantState } from '@/objects'
 import React, { useContext, useState } from 'react'
-import { StyleSheet, TouchableOpacity, View as ViewRN } from 'react-native'
+import { TouchableOpacity, View as ViewRN } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { CheckboxTilesContext } from '../context'
 import { CheckboxTileNativeRef, CheckboxTileProps } from './CheckboxTileProps'
 
@@ -52,7 +53,7 @@ const CheckboxTile = React.forwardRef<CheckboxTileNativeRef, CheckboxTileProps>(
     const [stickerHeight, setStickerHeight] = useState<number>(0)
     const { isGrid } = useContext(CheckboxTilesContext)
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       container: {
         flexDirection: 'row',
         paddingBottom: 5,

--- a/packages/react/components/chips/Chips.native.tsx
+++ b/packages/react/components/chips/Chips.native.tsx
@@ -3,7 +3,8 @@ import { Spacer, SpacerSize } from '@/components/spacer'
 import { Text, TextLevels } from '@/components/text'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import React, { useContext, useEffect, useState } from 'react'
-import { GestureResponderEvent, StyleSheet, TouchableOpacity } from 'react-native'
+import { GestureResponderEvent, TouchableOpacity } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { Icon, IconColor, IconName, IconSize } from '../icon'
 import { ChipsNativeRef, ChipsProps } from './ChipsProps'
 import { ChipsContext } from './list/ChipsList.native'
@@ -26,7 +27,7 @@ const Chips = React.forwardRef<ChipsNativeRef, ChipsProps>(
       setActiveItem(active || false)
     }, [active])
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       chips: {
         backgroundColor:
           (disabled && getColorStyle(TrilogyColor.NEUTRAL_FADE)) ||

--- a/packages/react/components/chips/list/ChipsList.native.tsx
+++ b/packages/react/components/chips/list/ChipsList.native.tsx
@@ -1,6 +1,7 @@
 import { ComponentName } from '@/components/enumsComponentsName'
 import React, { createContext } from 'react'
-import { ScrollView, StyleSheet, View } from 'react-native'
+import { ScrollView, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { ChipsListNativeRef, ChipsListProps } from './ChipsListProps'
 
 export const ChipsContext = createContext({ isMultiple: false })
@@ -15,7 +16,7 @@ export const ChipsContext = createContext({ isMultiple: false })
  */
 const ChipsList = React.forwardRef<ChipsListNativeRef, ChipsListProps>(
   ({ children, multiple, scrollable = true, testId, ...others }, ref): JSX.Element => {
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       container: {
         flexWrap: 'wrap',
         flexDirection: 'row',

--- a/packages/react/components/columns/column/Column.native.tsx
+++ b/packages/react/components/columns/column/Column.native.tsx
@@ -17,7 +17,7 @@ const Column = React.memo(React.forwardRef<ColumnNativeRef, ColumnProps>(
     const { width, realGap, scrollable, childrensLength } = React.useContext(ColumnsContext)
 
     const calculatedWidth = React.useMemo(() =>
-      (size ? (size / 12) * width - realGap * ((childrensLength - 1) / childrensLength) : null),
+      (size && width > 0 ? (size / 12) * width - realGap * ((childrensLength - 1) / childrensLength) : null),
       [size, width, realGap, childrensLength]
     )
 
@@ -33,7 +33,7 @@ const Column = React.memo(React.forwardRef<ColumnNativeRef, ColumnProps>(
         flex: narrow ? 0 : 1,
         flexGrow: size || narrow ? 0 : 1,
         flexShrink: narrow ? 1 : 0,
-        flexBasis: calculatedWidth || 'auto',
+        flexBasis: calculatedWidth || (size ? `${(size / 12) * 100}%` : 'auto'),
       }),
       [narrow, size, calculatedWidth],
     )

--- a/packages/react/components/countdown/Countdown.native.tsx
+++ b/packages/react/components/countdown/Countdown.native.tsx
@@ -3,7 +3,8 @@ import { Text, TextLevels } from '@/components/text'
 import { Title, TitleLevels } from '@/components/title'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import React, { useEffect, useState } from 'react'
-import { StyleSheet, Text as TextNative, View } from 'react-native'
+import { Text as TextNative, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { getTypographyBoldStyle, TypographyBold } from '../../objects/Typography'
 import { CountdownFormat, CountdownUnite } from './CountdownEnum'
 import { CountdownNativeRef, CountdownProps } from './CountdownProps'
@@ -124,7 +125,7 @@ const Countdown = React.forwardRef<CountdownNativeRef, CountdownProps>(
       }
     }, [timer, event, init])
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       countdown: {
         alignSelf: centered ? 'center' : 'flex-start',
         backgroundColor: getColorStyle(TrilogyColor.ACCENT_FADE),

--- a/packages/react/components/datepicker/DatePicker.native.tsx
+++ b/packages/react/components/datepicker/DatePicker.native.tsx
@@ -12,6 +12,7 @@ import {
   Platform,
   Modal
 } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { DatePickerProps } from './DatePickerProps'
 
 /**
@@ -262,7 +263,7 @@ const DatePicker = forwardRef<View, DatePickerProps>(
       }
     }, [value, formatDateForDisplay, isFocused])
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       container: {
         width: '100%',
       },

--- a/packages/react/components/divider/Divider.native.tsx
+++ b/packages/react/components/divider/Divider.native.tsx
@@ -3,7 +3,8 @@ import { Icon, IconColor } from '@/components/icon'
 import { Text } from '@/components/text'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import * as React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { DividerNativeRef, DividerProps } from './DividerProps'
 
 /**
@@ -20,7 +21,7 @@ const Divider = React.forwardRef<DividerNativeRef, DividerProps>(({ content, unb
   const [containerWidth, setContainerWidth] = React.useState(0)
   const dividerColor = getColorStyle(TrilogyColor.NEUTRAL)
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     divider: {
       marginBottom: 16,
       marginTop: 16,

--- a/packages/react/components/fab/Fab.native.tsx
+++ b/packages/react/components/fab/Fab.native.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
-import { StyleSheet, TouchableOpacity } from "react-native"
+import { TouchableOpacity } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { FabNativeRef, FabProps } from "./FabProps"
 import { Alignable, getColorStyle, TrilogyColor, TypographyBold, TypographyColor } from "@/objects"
 import { Icon, IconColor, IconName, IconSize } from "@/components/icon"
@@ -34,7 +35,7 @@ const Fab =  React.forwardRef<FabNativeRef, FabProps>(({
                disabled,
                testId
              }, ref): JSX.Element => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     button: {
       backgroundColor: getColorStyle(TrilogyColor.MAIN),
       justifyContent: "center",

--- a/packages/react/components/flex-box/FlexBox.native.tsx
+++ b/packages/react/components/flex-box/FlexBox.native.tsx
@@ -2,7 +2,8 @@ import { ComponentName } from '@/components/enumsComponentsName'
 import { getAlignStyle } from '@/objects/facets/Alignable'
 import { getJustifyStyle } from '@/objects/facets/Justifiable'
 import React, { useState } from 'react'
-import { Dimensions, LayoutChangeEvent, ScrollView, StyleSheet, View } from 'react-native'
+import { Dimensions, LayoutChangeEvent, ScrollView, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { ColumnsGapValue } from '../columns'
 import { FlexBoxNativeRef, FlexBoxProps } from './FlexBoxProps'
 import { FlexBoxContext } from './context'
@@ -43,7 +44,7 @@ const FlexBox = React.forwardRef<FlexBoxNativeRef, FlexBoxProps>(
     const gapIndex = (gap && typeof gap === 'number' && gap) || (gap && gap?.mobile) || 0
     const realGap = React.useMemo(() => (typeof gap === 'undefined' ? 8 : ColumnsGapValue[gapIndex]), [gap])
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       columns: {
         flexDirection: !isValueDirection ? direction?.mobile : direction,
         gap: realGap,

--- a/packages/react/components/hero/Hero.native.tsx
+++ b/packages/react/components/hero/Hero.native.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
-import { ImageBackground, StyleSheet, TouchableOpacity, View } from 'react-native'
+import { ImageBackground, TouchableOpacity, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { Box } from '@/components/box'
 import { ComponentName } from '@/components/enumsComponentsName'
 import { HeroNativeRef, HeroProps } from '@/components/hero/HeroProps'
@@ -30,7 +31,7 @@ const Hero = React.forwardRef<HeroNativeRef, HeroProps>(
     const overlapMargin = backgroundHeight ? overlapHeight - backgroundHeight / 2 : overlapHeight - 60
     const marginBottomOverlap = isSecondOverlapNotEmpty ? 70 : 60
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       hero: {
         width: '100%',
         minHeight: 150,

--- a/packages/react/components/icon/Icon.native.tsx
+++ b/packages/react/components/icon/Icon.native.tsx
@@ -7,9 +7,14 @@ import { isIOS } from '@/helpers/device.native'
 import { getAlignStyle } from '@/objects/facets/Alignable'
 import { getColorStyle, TrilogyColor, TrilogyColorValues } from '@/objects/facets/Color'
 import React, { useContext } from 'react'
-import { StyleSheet, TouchableOpacity, View } from 'react-native'
-import { WithLocalSvg } from 'react-native-svg/css'
+import { TouchableOpacity, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { Skeleton } from '../skeleton'
+
+const resolveSvg = (mod: unknown): React.ComponentType<Record<string, unknown>> => {
+  const asModule = mod as { __esModule?: boolean; default?: React.ComponentType<Record<string, unknown>> }
+  return (asModule && asModule.__esModule ? asModule.default : mod) as React.ComponentType<Record<string, unknown>>
+}
 
 /**
  * Icon Component
@@ -68,7 +73,7 @@ const Icon = React.forwardRef<IconNativeRef, IconProps>(
       (size === IconSize.SMALLER && 38) ||
       32
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       rootView: {
         alignSelf: getAlignStyle(align),
       },
@@ -129,12 +134,14 @@ const Icon = React.forwardRef<IconNativeRef, IconProps>(
     let iconView: JSX.Element = <View></View>
 
     if (name && icons) {
-      if (stretched && !circled) {
+      const iconKey = name.toString().replace('tri-picto-', '').replace('tri-', '')
+      const SvgComponent = resolveSvg(icons[iconKey])
+      if (SvgComponent) {
+        if (stretched && !circled) {
         iconView = (
           <View style={styles.stretched} testID={`${testId}-stretched`}>
-            <WithLocalSvg
+            <SvgComponent
               style={[styles.iconCircled, styles.icon]}
-              asset={icons[name.toString().replace('tri-picto-', '').replace('tri-', '')]}
               width={defaultSize}
               height={defaultSize}
               color={getColorStyle(TrilogyColor.BACKGROUND)}
@@ -144,9 +151,8 @@ const Icon = React.forwardRef<IconNativeRef, IconProps>(
       } else if (circled) {
         iconView = (
           <View style={styles.circled} testID={`${testId}-circled`}>
-            <WithLocalSvg
+            <SvgComponent
               style={[styles.iconCircled, styles.icon]}
-              asset={icons[name.toString().replace('tri-picto-', '').replace('tri-', '')]}
               width={defaultSize}
               height={defaultSize}
               color={iconColor}
@@ -156,15 +162,15 @@ const Icon = React.forwardRef<IconNativeRef, IconProps>(
       } else {
         iconView = (
           <View style={styles.iconContainer} {...others}>
-            <WithLocalSvg
+            <SvgComponent
               style={[styles.icon, style]}
-              asset={icons[name.toString().replace('tri-picto-', '').replace('tri-', '')]}
               width={defaultSize}
               height={defaultSize}
               color={iconColor}
             />
           </View>
         )
+        }
       }
     }
 

--- a/packages/react/components/image/Image.native.tsx
+++ b/packages/react/components/image/Image.native.tsx
@@ -1,6 +1,7 @@
 import { ComponentName } from '@/components/enumsComponentsName'
 import * as React from 'react'
-import { Image as ImageNative, StyleSheet, TouchableOpacity, View } from 'react-native'
+import { Image as ImageNative, TouchableOpacity, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { ImageCache, ImageNativeRef, ImageProps } from './ImageProps'
 
 /**
@@ -17,13 +18,12 @@ import { ImageCache, ImageNativeRef, ImageProps } from './ImageProps'
  */
 const Image = React.forwardRef<ImageNativeRef, ImageProps>(
   ({ src, alt = '', circled, width, height, onClick, cache, testId, ...others }, ref): JSX.Element => {
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       image: {
         width: width ? width : '100%',
         height: height ? height : '100%',
         borderRadius: circled ? 100 : 0,
         overflow: circled ? 'hidden' : 'visible',
-        resizeMode: circled ? undefined : 'contain',
       },
     })
 
@@ -53,7 +53,7 @@ const Image = React.forwardRef<ImageNativeRef, ImageProps>(
           }
 
     const image = (
-      <ImageNative testID={testId} ref={ref} style={styles.image} accessibilityLabel={alt} source={imageSource} {...others} alt={alt} />
+      <ImageNative testID={testId} ref={ref} resizeMode={circled ? undefined : 'contain'} style={styles.image} accessibilityLabel={alt} source={imageSource} {...others} alt={alt} />
     )
 
     return onClick ? (

--- a/packages/react/components/input/Input.native.tsx
+++ b/packages/react/components/input/Input.native.tsx
@@ -7,15 +7,8 @@ import { Align } from '@/objects/facets/Alignable'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import { StatusState } from '@/objects/facets/Status'
 import React, { useCallback, useEffect, useState } from 'react'
-import {
-  Keyboard,
-  NativeSyntheticEvent,
-  StyleSheet,
-  TextInput,
-  TextInputSubmitEditingEventData,
-  TouchableOpacity,
-  View,
-} from 'react-native'
+import { Keyboard, NativeSyntheticEvent, TextInput, TextInputSubmitEditingEventData, TouchableOpacity, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { Spacer, SpacerSize } from '../spacer'
 import {
   InputAutoCapitalize,
@@ -165,7 +158,7 @@ const Input = React.forwardRef<InputNativeRef, InputNativeProps>(
 
     const hasIcon = iconNameLeft || iconNameRight || false
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       input: {
         paddingLeft:
           (((iconNameLeft && isFocused) || (type === InputType.SEARCH && isFocused)) && 39) ||

--- a/packages/react/components/link/Link.native.tsx
+++ b/packages/react/components/link/Link.native.tsx
@@ -3,7 +3,8 @@ import { Icon } from '@/components/icon'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import * as React from 'react'
 import { useState } from 'react'
-import { Linking, StyleSheet, Text, View } from 'react-native'
+import { Linking, Text, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { LinkNativeRef, LinkPropsNative } from './LinkProps'
 
 /**
@@ -20,7 +21,7 @@ const Link = React.forwardRef<LinkNativeRef, LinkPropsNative>(
   ({ children, to, onClick, testId, accessibilityLabel, iconName, inverted, ...others }, ref): JSX.Element => {
     const [pressedLink, setPressedLink] = useState(false)
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       link: {
         color: getColorStyle(
           (pressedLink && TrilogyColor.MAIN_FADE) || (inverted && TrilogyColor.BACKGROUND) || TrilogyColor.MAIN,

--- a/packages/react/components/list/item/ListItem.native.tsx
+++ b/packages/react/components/list/item/ListItem.native.tsx
@@ -5,7 +5,8 @@ import { ListItemNativeRef, ListItemProps } from '@/components/list/item/ListIte
 import { Text, TextLevels } from '@/components/text'
 import { getColorStyle, TrilogyColor, TypographyBold } from '@/objects'
 import React, { useContext, useEffect, useId, useMemo } from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 
 /**
  * ListItem Component
@@ -24,7 +25,7 @@ const ListItem = React.forwardRef<ListItemNativeRef, ListItemProps>(
       setChildIndexes((prev) => [...prev, id])
     }, [id])
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       text: {
         paddingHorizontal: 16,
       },

--- a/packages/react/components/modal/Modal.native.tsx
+++ b/packages/react/components/modal/Modal.native.tsx
@@ -13,6 +13,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated'
 import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler'
@@ -132,7 +133,7 @@ const Modal = React.forwardRef<ModalNativeRef, ModalProps>(
     }))
 
     const backdropAnimatedStyle = useAnimatedStyle(() => ({
-      backgroundColor: `rgba(0, 0, 0, ${backdropOpacity.value})`,
+      backgroundColor: `rgba(0, 0, 0, ${Math.max(0, Math.min(1, backdropOpacity.value)).toFixed(3)})`,
     }))
 
     const { bottom: bottomInset } = useSafeAreaInsets()
@@ -191,7 +192,7 @@ Modal.displayName = ComponentName.Modal
 
 export default Modal
 
-const styles = StyleSheet.create({
+const styles = memoStyles({
   overlay: {
     flex: 1,
     justifyContent: 'flex-end',

--- a/packages/react/components/modal/body/ModalBody.native.tsx
+++ b/packages/react/components/modal/body/ModalBody.native.tsx
@@ -3,6 +3,7 @@ import { isIOS } from '@/helpers/device.native'
 import { getColorStyle, TrilogyColor } from '@/objects'
 import * as React from 'react'
 import { ScrollView, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { ModalContext } from '../context/ModalContext'
 import { ModalBodyNativeRef, ModalBodyProps } from './ModalBodyProps'
 
@@ -14,6 +15,9 @@ import { ModalBodyNativeRef, ModalBodyProps } from './ModalBodyProps'
  */
 const ModalBody = React.forwardRef<ModalBodyNativeRef, ModalBodyProps>(({ children, testId, ...others }, ref): JSX.Element => {
   const { handleOnScroll, scrollViewRef, isFooter } = React.useContext(ModalContext)
+  const insets = useSafeAreaInsets()
+  const defaultBottom = isIOS ? 40 : 16
+  const bottomPadding = isFooter ? 8 : isIOS ? Math.max(defaultBottom, insets.bottom) : defaultBottom
 
   return (
     <ScrollView
@@ -28,7 +32,7 @@ const ModalBody = React.forwardRef<ModalBodyNativeRef, ModalBodyProps>(({ childr
           {
             backgroundColor: getColorStyle(TrilogyColor.BACKGROUND),
             paddingTop: 8,
-            paddingBottom: isFooter ? 8 : isIOS ? 40 : 16,
+            paddingBottom: bottomPadding,
           },
         ]}
         testID={testId}

--- a/packages/react/components/modal/footer/ModalFooter.native.tsx
+++ b/packages/react/components/modal/footer/ModalFooter.native.tsx
@@ -3,7 +3,9 @@ import { Title, TitleLevels } from '@/components/title'
 import { isIOS } from '@/helpers/device.native'
 import { getColorStyle, TrilogyColor } from '@/objects'
 import * as React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { ModalContext } from '../context'
 import { ModalFooterProps, ModalFooterNativeRef } from './ModalFooterProps'
 
@@ -15,6 +17,8 @@ import { ModalFooterProps, ModalFooterNativeRef } from './ModalFooterProps'
  */
 const ModalFooter = React.forwardRef<ModalFooterNativeRef, ModalFooterProps>(({ children, testId, ...others }, ref): JSX.Element => {
   const { setIsFooter } = React.useContext(ModalContext)
+  const insets = useSafeAreaInsets()
+  const bottomPadding = isIOS ? Math.max(40, insets.bottom) : 18
 
   React.useEffect(() => {
     setIsFooter(true)
@@ -25,7 +29,7 @@ const ModalFooter = React.forwardRef<ModalFooterNativeRef, ModalFooterProps>(({ 
   }, [])
 
   return (
-    <View ref={ref} style={[styles.container]} testID={testId} {...others}>
+    <View ref={ref} style={[styles.container, { paddingBottom: bottomPadding }]} testID={testId} {...others}>
       <View style={[{ backgroundColor: getColorStyle(TrilogyColor.BACKGROUND) }]}>
         {(typeof children === 'string' && (
           <Title level={TitleLevels.THREE} style={styles.title}>
@@ -42,7 +46,7 @@ ModalFooter.displayName = ComponentName.ModalFooter
 
 export default ModalFooter
 
-const styles = StyleSheet.create({
+const styles = memoStyles({
   container: {
     paddingBottom: isIOS ? 40 : 18,
     paddingTop: 16,

--- a/packages/react/components/pagination/Pagination.native.tsx
+++ b/packages/react/components/pagination/Pagination.native.tsx
@@ -3,7 +3,8 @@ import { Icon, IconName, IconSize } from '@/components/icon'
 import { Text } from '@/components/text'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import React, { useEffect, useRef, useState } from 'react'
-import { StyleSheet, TouchableOpacity, View } from 'react-native'
+import { TouchableOpacity, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { Pager } from './PaginationEnum'
 import { PaginationNativeProps, PaginationNativeRef } from './PaginationProps'
 
@@ -69,7 +70,7 @@ const Pagination = React.forwardRef<PaginationNativeRef, PaginationNativeProps>(
       }
     }, [currentPage])
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       container: {
         flexDirection: 'row',
         alignItems: 'center',

--- a/packages/react/components/popover/Popover.native.tsx
+++ b/packages/react/components/popover/Popover.native.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
 import { PopoverNativeRef, PopoverProps } from './PopoverProps'
 import { ComponentName } from '@/components/enumsComponentsName'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { getColorStyle, TrilogyColor } from '@/objects'
 import { PopoverDirection } from './PopoverEnum'
 
@@ -12,7 +13,7 @@ import { PopoverDirection } from './PopoverEnum'
  * @param active {boolean} Is the popover active
  */
 const Popover = React.forwardRef<PopoverNativeRef, PopoverProps>(({ children, active = false, direction }, ref): JSX.Element => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     container: {
       alignItems: 'center',
     },

--- a/packages/react/components/price/Price.native.tsx
+++ b/packages/react/components/price/Price.native.tsx
@@ -2,7 +2,8 @@ import { ComponentName } from '@/components/enumsComponentsName'
 import { Spacer, SpacerSize } from '@/components/spacer'
 import { StatesContext } from '@/context/providerStates'
 import React, { useContext, useMemo } from 'react'
-import { StyleSheet, Text, View } from 'react-native'
+import { Text, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { Alignable, getColorStyle, getTypographyBoldStyle, TrilogyColor, TypographyBold } from '../../objects'
 import { PriceLevel } from './PriceEnum'
 import { checkCents } from './PriceHelpers'
@@ -147,7 +148,7 @@ const Price = React.forwardRef<PriceNativeRef, PriceProps>(
       )
     }
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       container: {
         flexDirection: 'row',
         alignSelf:

--- a/packages/react/components/progress/Progress.native.tsx
+++ b/packages/react/components/progress/Progress.native.tsx
@@ -3,7 +3,8 @@ import { Text, TextLevels } from '@/components/text'
 import { View } from '@/components/view'
 import { getColorStyle, getStatusStyle, TrilogyColor } from '@/objects'
 import React, { useEffect, useRef } from 'react'
-import { Animated, StyleSheet } from 'react-native'
+import { Animated } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { ProgressNativeRef, ProgressProps } from './ProgressProps'
 
 /**
@@ -43,7 +44,7 @@ const Progress = React.forwardRef<ProgressNativeRef, ProgressProps>(
       extrapolate: 'clamp',
     })
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       progress: {
         flexDirection: 'row',
         width: '100%',

--- a/packages/react/components/progress/radial/ProgressRadial.native.tsx
+++ b/packages/react/components/progress/radial/ProgressRadial.native.tsx
@@ -4,7 +4,8 @@ import { Title, TitleLevels } from '@/components/title'
 import { getAlignStyle, TypographyAlign, TypographyBold } from '@/objects'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import * as React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { Skeleton } from '../../skeleton'
 import { ProgressRadialNativeRef, ProgressRadialProps } from './ProgressRadialProps'
 import { AnimatedCircularProgress } from './react-native-circular-progress'
@@ -52,7 +53,7 @@ const ProgressRadial = React.forwardRef<ProgressRadialNativeRef, ProgressRadialP
     const progressRadialWidth = small ? 100 : 124
     const progressRadialSkeletonRadius = small ? 50 : 124
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       container: {
         alignSelf: getAlignStyle(align),
       },

--- a/packages/react/components/prompt/Prompt.native.tsx
+++ b/packages/react/components/prompt/Prompt.native.tsx
@@ -1,7 +1,8 @@
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import { getRadiusStyle } from '@/objects/facets/Radius'
 import React, { useContext } from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { ComponentName } from '../enumsComponentsName'
 import { RadiusValues } from '../image'
 import { PromptNativeRef, PromptProps } from './PromptProps'
@@ -10,7 +11,7 @@ import { PromptContext, PromptProvider } from './context'
 const PromptElm = React.forwardRef<PromptNativeRef, PromptProps>(({ disabled, ...others }, ref) => {
   const { isFocused, isDisabled } = useContext(PromptContext)
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     view: {
       borderWidth: isFocused ? 2 : 1,
       borderRadius: getRadiusStyle(RadiusValues.SMALL),

--- a/packages/react/components/prompt/files/PromptFiles.native.tsx
+++ b/packages/react/components/prompt/files/PromptFiles.native.tsx
@@ -1,7 +1,8 @@
 import { GapSize } from '@/components/columns'
 import { ComponentName } from '@/components/enumsComponentsName'
 import React, { useContext, useEffect, useMemo } from 'react'
-import { ScrollView, StyleSheet, View } from 'react-native'
+import { ScrollView, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { PromptContext } from '../context'
 import { PromptFilesNativeRef, PromptFilesProps } from './PromptFilesProps'
 
@@ -9,7 +10,7 @@ const PromptFiles = React.forwardRef<PromptFilesNativeRef, PromptFilesProps>(({ 
   const { setFiles } = useContext(PromptContext)
   const childrenLength = useMemo(() => React.Children.count(children), [children])
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     scrollViewContainer: {
       flexDirection: 'row',
       gap: GapSize.EIGHT * 2,

--- a/packages/react/components/prompt/files/file/PromptFile.native.tsx
+++ b/packages/react/components/prompt/files/file/PromptFile.native.tsx
@@ -8,7 +8,8 @@ import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import { getRadiusStyle } from '@/objects/facets/Radius'
 import { TypographyBold } from '@/objects/Typography'
 import React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { PromptFileNativeRef, PromptFileProps } from './PromptFileProps'
 
 const HEIGHT_ITEM = 64
@@ -18,7 +19,7 @@ const MAX_WIDTH_FILE = 264
 const PromptFile = React.forwardRef<PromptFileNativeRef, PromptFileProps>(({ onDelete, src, name, type }, ref) => {
   const backgroundTimes = getColorStyle(TrilogyColor.MAIN_FADE)
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     cardImg: {
       backgroundColor: getColorStyle(TrilogyColor.MAIN_FADE),
       borderRadius: getRadiusStyle(RadiusValues.SMALL),

--- a/packages/react/components/prompt/toolbar/PromptToolbar.native.tsx
+++ b/packages/react/components/prompt/toolbar/PromptToolbar.native.tsx
@@ -2,13 +2,14 @@ import { GapSize } from '@/components/columns'
 import { ComponentName } from '@/components/enumsComponentsName'
 import { SpacerSize } from '@/components/spacer'
 import React, { useContext } from 'react'
-import { Pressable, StyleSheet } from 'react-native'
+import { Pressable } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { PromptContext } from '../context'
 import { PromptToolbarNativeRef, PromptToolbarProps } from './PromptToolbarProps'
 
 const PromptToolbar = React.forwardRef<PromptToolbarNativeRef, PromptToolbarProps>(({ ...others }, ref) => {
   const { textareaRef } = useContext(PromptContext)
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     view: {
       flexDirection: 'row',
       gap: GapSize.EIGHT,

--- a/packages/react/components/prompt/toolbar/microphone/PromptMicrophone.native.tsx
+++ b/packages/react/components/prompt/toolbar/microphone/PromptMicrophone.native.tsx
@@ -2,7 +2,8 @@ import { ComponentName } from '@/components/enumsComponentsName'
 import { Icon, IconName, IconSize } from '@/components/icon'
 import { TrilogyColor } from '@/objects'
 import React, { useContext } from 'react'
-import { StyleSheet } from 'react-native'
+import {  } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { PromptContext } from '../../context'
 import PromptButton from '../tools/button/PromptButton.native'
 import { PromptMicrophoneNativeRef, PromptMicrophoneProps } from './PromptMicrophoneProps'
@@ -19,7 +20,7 @@ const PromptMicrophone = React.forwardRef<PromptMicrophoneNativeRef, PromptMicro
     const { isTyping, setIsSpeech, isDisabled } = useContext(PromptContext)
     const isDisable = isDisabled || disabled
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       icon: {
         flexDirection: 'row',
         justifyContent: 'center',

--- a/packages/react/components/prompt/toolbar/submit/PromptSubmit.native.tsx
+++ b/packages/react/components/prompt/toolbar/submit/PromptSubmit.native.tsx
@@ -2,7 +2,8 @@ import { ComponentName } from '@/components/enumsComponentsName'
 import { Icon, IconName, IconSize } from '@/components/icon'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { PromptContext } from '../../context'
 import PromptButton from '../tools/button/PromptButton.native'
 import { PromptSubmitNativeRef, PromptSubmitProps, PromptSubmitStatus } from './PromptSubmitProps'
@@ -38,7 +39,7 @@ const PromptSubmit = React.forwardRef<PromptSubmitNativeRef, PromptSubmitProps>(
       [statusSubmit, text, files],
     )
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       icon: {
         flexDirection: 'row',
         justifyContent: 'center',

--- a/packages/react/components/prompt/toolbar/tools/PromptTools.native.tsx
+++ b/packages/react/components/prompt/toolbar/tools/PromptTools.native.tsx
@@ -1,11 +1,12 @@
 import { GapSize } from '@/components/columns'
 import { ComponentName } from '@/components/enumsComponentsName'
 import React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { PromptToolsNativeRef, PromptToolsProps } from './PromptToolsProps'
 
 const PromptTools = React.forwardRef<PromptToolsNativeRef, PromptToolsProps>(({ ...others }, ref) => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     view: {
       flexDirection: 'row',
       gap: GapSize.EIGHT,

--- a/packages/react/components/prompt/toolbar/tools/button/PromptButton.native.tsx
+++ b/packages/react/components/prompt/toolbar/tools/button/PromptButton.native.tsx
@@ -4,7 +4,8 @@ import { PromptContext } from '@/components/prompt/context'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import { getRadiusStyle } from '@/objects/facets/Radius'
 import React, { useContext } from 'react'
-import { Pressable, StyleSheet } from 'react-native'
+import { Pressable } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { PromptButtonNativeRef, PromptButtonProps } from './PromptButtonProps'
 
 const PromptButton = React.forwardRef<PromptButtonNativeRef, PromptButtonProps>(
@@ -13,7 +14,7 @@ const PromptButton = React.forwardRef<PromptButtonNativeRef, PromptButtonProps>(
     const isDisable = isDisabled || disabled
     const isReadOnly = isReadonly || readOnly
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       button: {
         height: 36,
         minWidth: 36,

--- a/packages/react/components/prompt/toolbar/tools/inputFile/PromptInputFile.native.tsx
+++ b/packages/react/components/prompt/toolbar/tools/inputFile/PromptInputFile.native.tsx
@@ -3,7 +3,8 @@ import { Icon, IconName, IconSize } from '@/components/icon'
 import { PromptContext } from '@/components/prompt/context'
 import { TrilogyColor } from '@/objects'
 import React, { useContext } from 'react'
-import { StyleSheet } from 'react-native'
+import {  } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import PromptButton from '../button/PromptButton.native'
 import { PromptInputFileNativeRef, PromptInputFileProps } from './PromptInputFileProps'
 
@@ -12,7 +13,7 @@ const PromptInputFile = React.forwardRef<PromptInputFileNativeRef, PromptInputFi
     const { isDisabled } = useContext(PromptContext)
     const isDisable = isDisabled || disabled
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       icon: {
         flexDirection: 'row',
         justifyContent: 'center',

--- a/packages/react/components/radio/Radio.native.tsx
+++ b/packages/react/components/radio/Radio.native.tsx
@@ -3,7 +3,8 @@ import { RadioNativeProps, RadioNativeRef } from '@/components/radio/RadioProps'
 import { Text } from '@/components/text'
 import { getColorStyle, TrilogyColor } from '@/objects'
 import React from 'react'
-import { StyleSheet, TouchableOpacity, View } from 'react-native'
+import { TouchableOpacity, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 
 /**
  * Radio Component
@@ -18,7 +19,7 @@ import { StyleSheet, TouchableOpacity, View } from 'react-native'
  */
 const Radio = React.forwardRef<RadioNativeRef, RadioNativeProps>(
   ({ id = React.useId(), checked, name, onChange, disabled, readonly, label, value }, ref): JSX.Element => {
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       container: {
         flexDirection: 'row',
         alignItems: 'center',

--- a/packages/react/components/radio/list/RadioList.native.tsx
+++ b/packages/react/components/radio/list/RadioList.native.tsx
@@ -5,7 +5,8 @@ import { SpacerSize } from '@/components/spacer'
 import { Text } from '@/components/text'
 import * as React from 'react'
 import type { RadioListNativeRef, RadioListProps } from './RadioListProps'
-import { StyleSheet } from 'react-native'
+import {  } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { isRequiredChild } from '@/helpers/require'
 import { TypographyColor } from '@/objects/Typography'
 
@@ -25,7 +26,7 @@ const SPACING_MATRIX: SpacingMatrix = [
  * @param label {string} RadioList label
  */
 const RadioList = React.forwardRef<RadioListNativeRef, RadioListProps>(({ children, label }, ref): JSX.Element => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
       label: {
         marginBottom: 8,
       },

--- a/packages/react/components/radio/tiles/RadioTiles.native.tsx
+++ b/packages/react/components/radio/tiles/RadioTiles.native.tsx
@@ -3,7 +3,8 @@ import { RadioTilesNativeRef, RadioTilesProps } from '@/components/radio/tiles/R
 import { SpacerSize } from '@/components/spacer'
 import { Alignable } from '@/objects/facets/Alignable'
 import React, { ReactNode, RefObject, useCallback, useMemo } from 'react'
-import { FlatList, StyleSheet, View } from 'react-native'
+import { FlatList, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { RadioTilesContext } from './context'
 
 /**
@@ -25,7 +26,7 @@ const RadioTiles = React.forwardRef<RadioTilesNativeRef, RadioTilesProps>(
       return numberCols.mobile || numberCols.tablet
     }, [numberCols])
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       container: {
         flexDirection: 'row',
         flexWrap: 'wrap',

--- a/packages/react/components/radio/tiles/tile/RadioTile.native.tsx
+++ b/packages/react/components/radio/tiles/tile/RadioTile.native.tsx
@@ -9,7 +9,8 @@ import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import { TypographyAlign, TypographyColor } from '@/objects/Typography'
 import { TypographyBold } from '@/objects/Typography/TypographyBold'
 import React, { useCallback, useContext, useMemo, useState } from 'react'
-import { StyleSheet, TouchableOpacity, View } from 'react-native'
+import { TouchableOpacity, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { RadioTilesContext } from '../context'
 
 /**
@@ -51,7 +52,7 @@ const RadioTile = React.forwardRef<RadioTileNativeRef, RadioTileNativeProps>(
     const { isGrid } = useContext(RadioTilesContext)
     const [stickerHeight, setStickerHeight] = useState<number>(0)
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       container: {
         flex: isGrid ? 1 : undefined,
         flexDirection: horizontal ? 'row' : 'column',
@@ -143,7 +144,7 @@ const RadioTile = React.forwardRef<RadioTileNativeRef, RadioTileNativeProps>(
 )
 
 const InputRadio = ({ checked, disabled }: { checked?: boolean; disabled?: boolean }): JSX.Element => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     input: {
       marginRight: 'auto',
       width: 18,

--- a/packages/react/components/range/Range.native.tsx
+++ b/packages/react/components/range/Range.native.tsx
@@ -2,7 +2,8 @@ import { ComponentName } from '@/components/enumsComponentsName'
 import { getColorStyle, TrilogyColor, TypographyBold } from '@/objects'
 import MultiSlider from '@ptomasroos/react-native-multi-slider'
 import * as React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { Text, TextLevels } from '../text'
 import { RangeNativeProps, RangeNativeRef } from './RangeProps'
 
@@ -21,7 +22,7 @@ const Range = React.forwardRef<RangeNativeRef, RangeNativeProps>(
     const [values, setValues] = React.useState<number[]>(value || simple ? [0] : [0, 100])
     const [width, setWidth] = React.useState<number>(0)
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       marker: {
         width: 20,
         height: 20,

--- a/packages/react/components/rows/Rows.native.tsx
+++ b/packages/react/components/rows/Rows.native.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { RowsNativeRef, RowsProps } from './RowsProps'
 import { ComponentName } from '@/components/enumsComponentsName'
 import { ColumnsGapValue, GapSize } from '@/components/columns/ColumnsTypes'
@@ -11,7 +12,7 @@ import { ColumnsGapValue, GapSize } from '@/components/columns/ColumnsTypes'
  */
 const Rows = React.forwardRef<RowsNativeRef, RowsProps>(({ children, gap, ...others }, ref): JSX.Element => {
   const realGap = (typeof gap === 'undefined' && 16) || ColumnsGapValue[gap as GapSize]
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     rows: {
       display: 'flex',
       flexDirection: 'column',

--- a/packages/react/components/rows/row/Row.native.tsx
+++ b/packages/react/components/rows/row/Row.native.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { RowNativeRef, RowProps } from './RowProps'
 import { ComponentName } from '@/components/enumsComponentsName'
 
@@ -9,7 +10,7 @@ import { ComponentName } from '@/components/enumsComponentsName'
  * @param children {React.ReactNode}
  */
 const Row = React.forwardRef<RowNativeRef, RowProps>(({ children, narrow, ...others }, ref): JSX.Element => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     row: {
       flexGrow: (narrow && 0) || 1,
       flexShrink: 1,

--- a/packages/react/components/scroll-view/ScrollView.native.tsx
+++ b/packages/react/components/scroll-view/ScrollView.native.tsx
@@ -2,7 +2,8 @@ import { ComponentName } from '@/components/enumsComponentsName'
 import { isAndroid, isIOS } from '@/helpers/device.native'
 import { getColorStyle, ScrollDirectionEnum } from '@/objects'
 import * as React from 'react'
-import { RefreshControl, ScrollView as ScrollViewNative, StyleSheet, View } from 'react-native'
+import { RefreshControl, ScrollView as ScrollViewNative, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { ScrollViewNativeRef, ScrollViewProps } from './ScrollViewProps'
 
 /**
@@ -44,7 +45,7 @@ const ScrollView = React.forwardRef<ScrollViewNativeRef, ScrollViewProps>(
       wait(2000).then(() => setRefreshing(false))
     }, [])
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       stickyContent: {
         flexGrow: 1,
         justifyContent: 'space-between',

--- a/packages/react/components/section/Section.native.tsx
+++ b/packages/react/components/section/Section.native.tsx
@@ -1,7 +1,8 @@
 import { ComponentName } from '@/components/enumsComponentsName'
 import { getColorStyle, TrilogyColor } from '@/objects'
 import * as React from 'react'
-import { ImageBackground, StyleSheet, View } from 'react-native'
+import { ImageBackground, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { SectionNativeRef, SectionProps } from './SectionProps'
 
 /**
@@ -15,7 +16,7 @@ import { SectionNativeRef, SectionProps } from './SectionProps'
 const Section = React.forwardRef<SectionNativeRef, SectionProps>(({ backgroundColor, backgroundSrc, children, style, ...others }, ref): JSX.Element => {
   const colorBgc = getColorStyle(TrilogyColor.BACKGROUND)
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     container: {
       backgroundColor: backgroundSrc ? undefined : backgroundColor ? getColorStyle(backgroundColor) : colorBgc,
       paddingVertical: 32,

--- a/packages/react/components/segment-control/SegmentControl.native.tsx
+++ b/packages/react/components/segment-control/SegmentControl.native.tsx
@@ -3,7 +3,8 @@ import { Text, TextLevels } from '@/components/text'
 import { View } from '@/components/view'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import React, { useState } from 'react'
-import { StyleSheet } from 'react-native'
+import {  } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import SegmentedControlItem from './item'
 import { SegmentControlNativeRef, SegmentControlProps } from './SegmentControlProps'
 
@@ -33,7 +34,7 @@ const SegmentControl = React.forwardRef<SegmentControlNativeRef, SegmentControlP
       }
     }
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       padding: {
         paddingLeft: 10,
         paddingRight: 10,

--- a/packages/react/components/segment-control/item/SegmentControlItem.native.tsx
+++ b/packages/react/components/segment-control/item/SegmentControlItem.native.tsx
@@ -1,7 +1,8 @@
 import { ComponentName } from '@/components/enumsComponentsName'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import React, { useEffect, useState } from 'react'
-import { StyleSheet, Text, TouchableOpacity } from 'react-native'
+import { Text, TouchableOpacity } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { SegmentControlItemNativeRef, SegmentControlItemProps } from './SegmentControlItemProps'
 
 /**
@@ -21,7 +22,7 @@ const SegmentControlItem = React.forwardRef<SegmentControlItemNativeRef, Segment
 }, ref): JSX.Element => {
   const [activeItem, setActiveItem] = useState<boolean>(active || false)
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     tabsItem: {
       flexDirection: 'column',
       flex: 1,

--- a/packages/react/components/select/option/SelectOption.native.tsx
+++ b/packages/react/components/select/option/SelectOption.native.tsx
@@ -6,7 +6,8 @@ import { Alignable } from '@/objects'
 import { TypographyBold } from '@/objects/Typography'
 import { TrilogyColor, getColorStyle } from '@/objects/facets/Color'
 import * as React from 'react'
-import { StyleSheet, TouchableOpacity } from 'react-native'
+import { TouchableOpacity } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { SelectOptionNativeRef, SelectOptionProps } from './SelectOptionProps'
 
 /**
@@ -18,7 +19,7 @@ import { SelectOptionNativeRef, SelectOptionProps } from './SelectOptionProps'
 const SelectOption = React.forwardRef<SelectOptionNativeRef, SelectOptionProps>(({ disabled, children, onClick, label, iconName, ...others }, ref): JSX.Element => {
   const { checked } = others as { checked: string }
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
         container: {
           backgroundColor: getColorStyle(disabled ? TrilogyColor.DISABLED_FADE : 'transparent'),
           width: '100%',

--- a/packages/react/components/spacer/Spacer.native.tsx
+++ b/packages/react/components/spacer/Spacer.native.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
-import { StyleSheet, View } from "react-native"
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { SpacerNativeRef, SpacerProps } from "./SpacerProps"
 import { ComponentName } from "@/components/enumsComponentsName"
 
@@ -9,7 +10,7 @@ import { ComponentName } from "@/components/enumsComponentsName"
  * @param horizontal {Boolean} If horizontal margin
  */
 const Spacer = React.forwardRef<SpacerNativeRef, SpacerProps>(({ size, horizontal }, ref): JSX.Element => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     spacer: {
       marginLeft: (horizontal && parseInt(size.toString())) || 0,
       marginTop: (!horizontal && parseInt(size.toString())) || 0,

--- a/packages/react/components/stepper/Stepper.native.tsx
+++ b/packages/react/components/stepper/Stepper.native.tsx
@@ -3,7 +3,8 @@ import { Icon, IconName, IconSize } from '@/components/icon'
 import { Text } from '@/components/text'
 import { TypographyBold, TypographyColor } from '@/objects'
 import * as React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { StepperNativeRef, StepperProps } from './StepperProps'
 
 interface ICurrentStep {
@@ -23,7 +24,7 @@ const Stepper = React.forwardRef<StepperNativeRef, StepperProps>(({ children, ..
     iconName: '',
   })
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     steppers: {
       flexDirection: 'row',
       flex: 1,

--- a/packages/react/components/sticker/Sticker.native.tsx
+++ b/packages/react/components/sticker/Sticker.native.tsx
@@ -4,7 +4,8 @@ import { Text } from '@/components/text'
 import { isIOS } from '@/helpers/device.native'
 import { getColorStyle, getVariantStyle, TrilogyColor, TypographyBold } from '@/objects'
 import * as React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { StickerNativeRef, StickerProps } from './StickerProps'
 
 /**
@@ -19,7 +20,7 @@ import { StickerNativeRef, StickerProps } from './StickerProps'
 const Sticker = React.forwardRef<StickerNativeRef, StickerProps>(
   ({ variant, small, outlined, label, iconName, accessibilityLabel, ...others }, ref): JSX.Element => {
     const defaultColor = getColorStyle(TrilogyColor.MAIN)
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       sticker: {
         flexDirection: 'row',
         justifyContent: 'center',

--- a/packages/react/components/switch/Switch.native.tsx
+++ b/packages/react/components/switch/Switch.native.tsx
@@ -2,7 +2,8 @@ import { ComponentName } from '@/components/enumsComponentsName'
 import { getStatusStyle } from '@/objects'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import React, { useEffect, useState } from 'react'
-import { Pressable, StyleSheet } from 'react-native'
+import { Pressable } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import Animated, {
   interpolate,
   interpolateColor,
@@ -56,7 +57,7 @@ const Switch = React.forwardRef<SwitchNativeRef, SwitchProps>(
       }
     })
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       track: {
         alignItems: 'flex-start',
         width: TRACK_WIDTH,

--- a/packages/react/components/table/Table.native.tsx
+++ b/packages/react/components/table/Table.native.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { getColorStyle, TrilogyColor } from '@/objects'
 import { TableBorderEnum, TableNativeRef, TableProps } from './TableProps'
 import { ComponentName } from '@/components/enumsComponentsName'
@@ -12,7 +13,7 @@ import { ComponentName } from '@/components/enumsComponentsName'
 const Table = React.forwardRef<TableNativeRef, TableProps>(({ children, border, ...others }, ref): JSX.Element => {
   const borderColor = getColorStyle(TrilogyColor.STROKE_FADE)
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     table: {
       width: '100%',
       backgroundColor: 'transparent',

--- a/packages/react/components/table/body/TableBody.native.tsx
+++ b/packages/react/components/table/body/TableBody.native.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
-import { StyleSheet, Text, View } from "react-native"
+import { Text, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { TableBodyNativeRef, TableBodyProps } from "./TableBodyProps"
 import { ComponentName } from "@/components/enumsComponentsName"
 
@@ -8,7 +9,7 @@ import { ComponentName } from "@/components/enumsComponentsName"
  * @param children {ReactNode} Children of Table Body
  */
 const TableBody = React.forwardRef<TableBodyNativeRef, TableBodyProps>(({ children, ...others }, ref): JSX.Element => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     body: {
       display: "flex",
       flexDirection: "column",

--- a/packages/react/components/table/head/TableHead.native.tsx
+++ b/packages/react/components/table/head/TableHead.native.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
-import { StyleSheet, Text, View } from "react-native"
+import { Text, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { TableHeadNativeRef, TableHeadProps } from "./TableHeadProps"
 import { ComponentName } from "@/components/enumsComponentsName"
 
@@ -8,7 +9,7 @@ import { ComponentName } from "@/components/enumsComponentsName"
  * @param children {ReactNode} children of Table Head
  */
 const TableHead = React.forwardRef<TableHeadNativeRef, TableHeadProps>(({ children, ...others }, ref): JSX.Element => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     head: {
       width: "100%",
       flexDirection: "row",

--- a/packages/react/components/table/td/TableTd.native.tsx
+++ b/packages/react/components/table/td/TableTd.native.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
-import { StyleSheet, Text, View } from "react-native"
+import { Text, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { TableTdNativeRef, TableTdProps } from "./TableTdProps"
 import { getColorStyle, TrilogyColor } from "@/objects"
 import { ComponentName } from "@/components/enumsComponentsName"
@@ -9,7 +10,7 @@ import { ComponentName } from "@/components/enumsComponentsName"
  * @param children {ReactNode} Table TD children
  */
 const TableTd = React.forwardRef<TableTdNativeRef, TableTdProps>(({ children, ...others }, ref): JSX.Element => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     table: {
       flexDirection: "column",
       flex: 1,

--- a/packages/react/components/table/th/TableTh.native.tsx
+++ b/packages/react/components/table/th/TableTh.native.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
-import { StyleSheet } from "react-native"
+import {  } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { TableThNativeRef, TableThProps } from "./TableThProps"
 import { View } from "@/components/view"
 import { Text } from "@/components/text"
@@ -11,7 +12,7 @@ import { ComponentName } from "@/components/enumsComponentsName"
  * @param children {ReactNode} children of table TH
  */
 const TableTh = React.forwardRef<TableThNativeRef, TableThProps>(({ children, ...others }, ref): JSX.Element => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     tableTh: {
       flexDirection: "column",
       flex: 1,

--- a/packages/react/components/table/tr/TableTr.native.tsx
+++ b/packages/react/components/table/tr/TableTr.native.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
-import { StyleSheet, TouchableOpacity } from 'react-native'
+import { TouchableOpacity } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { TableTrNativeRef, TableTrPropsNative } from './TableTrProps'
 import { View } from '@/components/view'
 import { Text, TextLevels } from '@/components/text'
@@ -20,7 +21,7 @@ const TableTr = React.forwardRef<TableTrNativeRef, TableTrPropsNative>(({
 }, ref): JSX.Element => {
   const [isExpanded, setIsExpended] = useState<boolean>(false)
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     tableTr: {
       flexDirection: "row",
       flex: 1,

--- a/packages/react/components/tabs/tab-list/TabList.native.tsx
+++ b/packages/react/components/tabs/tab-list/TabList.native.tsx
@@ -5,15 +5,8 @@ import Tab from '@/components/tabs/tab-list/tab/Tab'
 import { TabListNativeRef, TabListProps } from '@/components/tabs/tab-list/TabListProps'
 import { getColorStyle, TrilogyColor } from '@/objects'
 import React from 'react'
-import {
-  LayoutChangeEvent,
-  LayoutRectangle,
-  NativeScrollEvent,
-  NativeSyntheticEvent,
-  ScrollView,
-  StyleSheet,
-  View,
-} from 'react-native'
+import { LayoutChangeEvent, LayoutRectangle, NativeScrollEvent, NativeSyntheticEvent, ScrollView, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 
 /**
  * Tabs Nav Component
@@ -34,7 +27,7 @@ const TabList = React.forwardRef<TabListNativeRef, TabListProps>(({ children, ..
 
   React.useImperativeHandle(ref, () => TabListRef.current as ScrollView)
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     tabList: {
       flexDirection: 'row',
       backgroundColor: getColorStyle(inverted ? TrilogyColor.MAIN : 'transparent'),

--- a/packages/react/components/tabs/tab-list/tab/Tab.native.tsx
+++ b/packages/react/components/tabs/tab-list/tab/Tab.native.tsx
@@ -6,7 +6,8 @@ import { Text } from '@/components/text'
 import { TypographyAlign } from '@/objects'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import React from 'react'
-import { GestureResponderEvent, Linking, StyleSheet, TouchableOpacity, View } from 'react-native'
+import { GestureResponderEvent, Linking, TouchableOpacity, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 
 /**
  * Tabs Item Component
@@ -36,7 +37,7 @@ const Tab = React.forwardRef<TabNativeRef, TabProps>(
       [disabled, onClick, index, setActiveIndex, to, href],
     )
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       tab: {
         flex: fullwidth ? 1 : undefined,
         flexBasis: fullwidth ? 0 : undefined,

--- a/packages/react/components/tabs/tab-panels/TabPanels.native.tsx
+++ b/packages/react/components/tabs/tab-panels/TabPanels.native.tsx
@@ -4,7 +4,8 @@ import TabPanel from '@/components/tabs/tab-panels/tab-panel'
 import { TabPanelsNativeRef, TabPanelsProps } from '@/components/tabs/tab-panels/TabPanelsProps'
 import { getColorStyle, TrilogyColor } from '@/objects'
 import React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 
 /**
  * Tabs Nav Component
@@ -15,7 +16,7 @@ import { StyleSheet, View } from 'react-native'
 const TabPanels = React.forwardRef<TabPanelsNativeRef, TabPanelsProps>(({ children, ...others }, ref) => {
   const { inverted } = React.useContext(TabsContext)
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     tabPanels: {
       paddingVertical: 8,
       backgroundColor: getColorStyle(inverted ? TrilogyColor.MAIN : 'transparent'),

--- a/packages/react/components/tag/Tag.native.tsx
+++ b/packages/react/components/tag/Tag.native.tsx
@@ -3,7 +3,8 @@ import { Icon, IconColor, IconSize } from '@/components/icon'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import { getStatusStyle } from '@/objects/facets/Status'
 import React from 'react'
-import { StyleSheet, Text, View } from 'react-native'
+import { Text, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { TagNativeRef, TagProps } from './TagProps'
 
 /**
@@ -21,7 +22,7 @@ const Tag = React.forwardRef<TagNativeRef, TagProps>(
 
     const backgroundColor = variant && getStatusStyle(variant).backgroundColor
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       tag: {
         flexDirection: 'row',
         justifyContent: 'center',

--- a/packages/react/components/tag/list/TagList.native.tsx
+++ b/packages/react/components/tag/list/TagList.native.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { TagListNativeRef, TagListProps } from './TagListProps'
 import { ComponentName } from '@/components/enumsComponentsName'
 
@@ -9,7 +10,7 @@ import { ComponentName } from '@/components/enumsComponentsName'
  * @param id {string} Custom id attribute
  */
 const TagList = React.forwardRef<TagListNativeRef, TagListProps>(({ children, ...others }, ref): JSX.Element => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     tagList: {
       width: '100%',
       flexDirection: 'row',

--- a/packages/react/components/text/Text.native.tsx
+++ b/packages/react/components/text/Text.native.tsx
@@ -3,7 +3,8 @@ import { StatesContext } from '@/context/providerStates'
 import { getTypographyBoldStyle, setTypographyAlign, setTypographyColor } from '@/objects/Typography'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import React, { useContext } from 'react'
-import { StyleSheet, Text as TextNative } from 'react-native'
+import { Text as TextNative } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { Skeleton } from '../skeleton'
 import { TextLevels, TextLevelValues } from './TextEnum'
 import { TextNativeRef, TextProps } from './TextProps'
@@ -42,7 +43,7 @@ const Text = React.forwardRef<TextNativeRef, TextProps>(({
     )
   }
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     text: {
       fontFamily: getTypographyBoldStyle(typo),
       fontSize: textLevels(level as TextLevels | TextLevelValues),

--- a/packages/react/components/textarea/Textarea.native.tsx
+++ b/packages/react/components/textarea/Textarea.native.tsx
@@ -10,7 +10,8 @@ import { TypographyColor } from '@/objects'
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import { StatusState } from '@/objects/facets/Status'
 import React, { useEffect, useState } from 'react'
-import { StyleSheet, Text, TextInput, View } from 'react-native'
+import { Text, TextInput, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { SpacerSize } from '../spacer'
 import { Text as TrilogyText } from '../text'
 import { TextLevels } from '../text/TextEnum'
@@ -88,7 +89,7 @@ const Textarea = React.forwardRef<TextareaNativeRef, TextareaNativeProps>(
     const counterBackground = getColorStyle(disabled ? TrilogyColor.DISABLED : TrilogyColor.BACKGROUND)
     const placeholderTextColor = getColorStyle(disabled ? TrilogyColor.DISABLED : TrilogyColor.FONT_PLACEHOLDER)
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       textarea: {
         borderWidth: isFocus ? 2 : 1,
         borderRadius: 3,

--- a/packages/react/components/timeline/Timeline.native.tsx
+++ b/packages/react/components/timeline/Timeline.native.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
-import { StyleSheet, View } from "react-native"
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { TimelineNativeRef, TimelineProps } from "./TimelineProps"
 import { ComponentName } from "@/components/enumsComponentsName"
 
@@ -19,7 +20,7 @@ export const TimelineHeightContext = React.createContext<IContext>({
 
  */
 const Timeline = React.forwardRef<TimelineNativeRef, TimelineProps>(({ children }, ref): JSX.Element => {
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     container: {
       flexDirection: "column",
     },

--- a/packages/react/components/timeline/content/TimelineContent.native.tsx
+++ b/packages/react/components/timeline/content/TimelineContent.native.tsx
@@ -6,7 +6,8 @@ import { TimelineContentNativeRef, TimelineContentProps } from '@/components/tim
 import { TimelineItemContext } from '@/components/timeline/item/TimelineItem.native'
 import { TypographyColor } from '@/objects'
 import React, { useContext } from 'react'
-import { StyleSheet, TouchableOpacity, View } from 'react-native'
+import { TouchableOpacity, View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 
 /**
  * Timeline Content Component
@@ -20,7 +21,7 @@ const TimelineContent = React.forwardRef<TimelineContentNativeRef, TimelineConte
   ({ content, heading, linkLabel, linkTo, children }, ref): JSX.Element => {
     const timelineContextValues = useContext(TimelineItemContext)
 
-    const styles = StyleSheet.create({
+    const styles = memoStyles({
       container: {
         flex: 6,
         marginBottom: 8,

--- a/packages/react/components/timeline/item/TimelineItem.native.tsx
+++ b/packages/react/components/timeline/item/TimelineItem.native.tsx
@@ -2,7 +2,8 @@ import { ComponentName } from '@/components/enumsComponentsName'
 import { TimelineItemNativeRef, TimelineItemProps } from '@/components/timeline/item/TimelineItemProps'
 import { TimelineHeightContext } from '@/components/timeline/Timeline.native'
 import React, { createContext, useContext } from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 
 export const TimelineItemContext = createContext({ done: false, active: false, cancel: false })
 
@@ -17,7 +18,7 @@ export const TimelineItemContext = createContext({ done: false, active: false, c
 const TimelineItem = React.forwardRef<TimelineItemNativeRef, TimelineItemProps>(({ children, done, active, cancel }, ref): JSX.Element => {
   const { height, setHeight } = useContext(TimelineHeightContext)
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     item: {
       width: '100%',
       flexDirection: 'row',

--- a/packages/react/components/timeline/marker/TimelineMarker.native.tsx
+++ b/packages/react/components/timeline/marker/TimelineMarker.native.tsx
@@ -6,7 +6,8 @@ import { TimelineMarkerNativeRef, TimelineMarkerProps } from '@/components/timel
 import { TimelineHeightContext } from '@/components/timeline/Timeline.native'
 import { getColorStyle, TrilogyColor } from '@/objects'
 import React, { useContext } from 'react'
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 
 /**
  * TimelineMarker Native Component
@@ -18,7 +19,7 @@ const TimelineMarker = React.forwardRef<TimelineMarkerNativeRef, TimelineMarkerP
   const { active, done, cancel } = useContext(TimelineItemContext)
   const { height } = useContext(TimelineHeightContext)
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     marker: {
       flex: 1,
       alignSelf: 'flex-start',

--- a/packages/react/components/title/Title.native.tsx
+++ b/packages/react/components/title/Title.native.tsx
@@ -5,7 +5,8 @@ import { getTypographyBoldStyle, setTypographyAlign, setTypographyColor, Typogra
 import { getColorStyle, TrilogyColor } from '@/objects/facets/Color'
 import * as React from 'react'
 import { useContext } from 'react'
-import { StyleSheet, Text as TextNative, TouchableOpacity } from 'react-native'
+import { Text as TextNative, TouchableOpacity } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { Skeleton } from '../skeleton'
 import { TitleLevels } from './TitleEnum'
 import { TitleNativeRef, TitleProps } from './TitleProps'
@@ -78,7 +79,7 @@ const Title = React.forwardRef<TitleNativeRef, TitleProps>(({
     }
   }
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     text: {
       fontFamily: getTypographyBoldStyle(fontFamily),
       fontSize: titlesLevels(),

--- a/packages/react/components/view/View.native.tsx
+++ b/packages/react/components/view/View.native.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
-import { ImageBackground, StyleSheet, TouchableOpacity, View as ViewNative, } from "react-native"
+import { ImageBackground, TouchableOpacity, View as ViewNative } from 'react-native'
+import { memoStyles } from '@/helpers/memoStyles'
 import { getAlignStyle, getJustifyStyle, TrilogyColor } from "@/objects"
 import { getColorStyle } from "@/objects/facets/Color"
 import { ViewNativeRef, ViewProps } from "./ViewProps"
@@ -36,7 +37,7 @@ const View = React.forwardRef<ViewNativeRef, ViewProps>(({
   const viewColor =
     (backgroundColor && getColorStyle(backgroundColor as TrilogyColor)) || "transparent"
 
-  const styles = StyleSheet.create({
+  const styles = memoStyles({
     view: {
       flex: flexable ? 1 : 0,
       backgroundColor: viewColor,

--- a/packages/react/helpers/memoStyles.ts
+++ b/packages/react/helpers/memoStyles.ts
@@ -1,0 +1,18 @@
+const styleCache = new Map<string, unknown>()
+
+type CreateStyles = typeof import('react-native').StyleSheet.create
+
+/**
+ * Memoize a styles object to avoid recreating identical StyleSheet definitions
+ * on every render. Acts as a drop-in replacement for `StyleSheet.create`.
+ * @param styles Styles definition object
+ * @returns The memoized styles object
+ */
+export const memoStyles: CreateStyles = (styles) => {
+  const key = JSON.stringify(styles)
+  const cached = styleCache.get(key)
+  if (cached !== undefined) return cached as typeof styles
+  if (styleCache.size > 200) styleCache.clear()
+  styleCache.set(key, styles)
+  return styles
+}


### PR DESCRIPTION
…fixes

Apply the @trilogy-ds/react native patch used in mcare to the source:
- Add memoStyles helper and use it as a drop-in for StyleSheet.create across native components to avoid recreating identical styles on render
- Column: guard width > 0 and percentage flexBasis fallback
- CardImage/Image: pass resizeMode as prop instead of style
- Icon: resolve SVG component (esModule interop) with safe guard
- Modal: clamp backdrop opacity
- ModalBody/ModalFooter: safe-area aware bottom padding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved column sizing when explicit width ratios are used.
  * Prevented invalid modal backdrop opacity values.
  * Improved modal and footer spacing around device safe areas.
  * Enhanced native icon loading and gracefully handles unavailable icons.
  * Applied image resize settings more reliably across native components.

* **Performance**
  * Improved style reuse across native components, reducing repeated style creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->