### PR TITLE
TRIL-133 feat(calendar): add yearsOrder prop to control year selector order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ mangled
 packages/react/components/icon/iconsPath.ts
 packages/styles/assets/icons/*.scss
 /docs/templates/
+
+# CodeGraph
+.codegraph/

--- a/packages/react/components/calendar/Calendar.native.tsx
+++ b/packages/react/components/calendar/Calendar.native.tsx
@@ -374,7 +374,9 @@ const Calendar = React.forwardRef<View, CalendarProps>(
         }
       })
       if (currentYear && !isCurrentYearInclude) {
-        years = [{ value: currentYear, disabled: true }, ...years]
+        const currentYearEntry = { value: currentYear, disabled: true }
+        const shouldPrepend = isDesc ? currentYear > maxYear : currentYear < minYear
+        years = shouldPrepend ? [currentYearEntry, ...years] : [...years, currentYearEntry]
       }
       return years
     }, [minDate, maxDate, value, yearsOrder])

--- a/packages/react/components/calendar/Calendar.native.tsx
+++ b/packages/react/components/calendar/Calendar.native.tsx
@@ -6,6 +6,7 @@ import { Modal, Platform, ScrollView, StyleSheet, TouchableOpacity, View } from 
 import { ComponentName } from '../enumsComponentsName'
 import { Icon } from '../icon'
 import { Text } from '../text'
+import { CalendarYearsOrder } from './CalendarEnum'
 import { CalendarProps, ChangeEventCalendar } from './CalendarProps'
 
 const days = [
@@ -34,6 +35,7 @@ const checkIsRange = (date: ChangeEventCalendar): date is [Date, Date] | [Date] 
  * @param disabledDates {Date[]} List of disabled/unavailable dates
  * @param onChange {Function} Callback when selected date(s) change
  * @param onMonthChange {Function} Callback when the displayed month changes
+ * @param yearsOrder {CalendarYearsOrder} Order of years in the year selector (asc by default, desc from most recent to oldest)
  * @param testId {string} Test Id for Test Integration
  */
 const Calendar = React.forwardRef<View, CalendarProps>(
@@ -48,6 +50,7 @@ const Calendar = React.forwardRef<View, CalendarProps>(
       testId,
       onChange,
       onMonthChange,
+      yearsOrder = CalendarYearsOrder.ASC,
     },
     ref,
   ) => {
@@ -362,8 +365,9 @@ const Calendar = React.forwardRef<View, CalendarProps>(
       const maxYear = maxDate.getFullYear()
       const currentYear = value instanceof Date && value?.getFullYear()
       const isCurrentYearInclude = currentYear && currentYear >= minYear && currentYear <= maxYear
+      const isDesc = yearsOrder === CalendarYearsOrder.DESC
       let years = Array.from({ length: maxYear - minYear + 1 }, (_, i) => {
-        const year = minYear + i
+        const year = isDesc ? maxYear - i : minYear + i
         return {
           value: year,
           disabled: false,
@@ -373,7 +377,7 @@ const Calendar = React.forwardRef<View, CalendarProps>(
         years = [{ value: currentYear, disabled: true }, ...years]
       }
       return years
-    }, [minDate, maxDate, value])
+    }, [minDate, maxDate, value, yearsOrder])
 
     const availableMonths = React.useMemo(() => {
       const currentYear = visibleMonth.getFullYear()

--- a/packages/react/components/calendar/Calendar.stories.tsx
+++ b/packages/react/components/calendar/Calendar.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import CalendarComponent from './Calendar'
+import { CalendarYearsOrder } from './CalendarEnum'
 import type { CalendarProps, ChangeEventCalendar } from './CalendarProps'
 import React from 'react'
 
@@ -15,6 +16,7 @@ interface CalendarStoryArgs {
   disabled: boolean
   readOnly: boolean
   disabledDates: Date[]
+  yearsOrder: CalendarYearsOrder
 }
 
 const meta: Meta<CalendarStoryArgs> = {
@@ -65,6 +67,13 @@ const meta: Meta<CalendarStoryArgs> = {
       description: 'List of disabled dates',
       table: { category: 'Calendar' },
     },
+    yearsOrder: {
+      control: 'select',
+      options: [CalendarYearsOrder.ASC, CalendarYearsOrder.DESC],
+      name: 'yearsOrder',
+      description: 'Order of years in the year selector (asc: oldest to most recent, desc: most recent to oldest)',
+      table: { category: 'Calendar' },
+    },
   },
   args: {
     value: new Date(),
@@ -73,8 +82,9 @@ const meta: Meta<CalendarStoryArgs> = {
     disabled: false,
     readOnly: false,
     disabledDates: [],
+    yearsOrder: CalendarYearsOrder.ASC,
   },
-  render: ({ value, minDate, maxDate, disabled, readOnly, disabledDates }) => (
+  render: ({ value, minDate, maxDate, disabled, readOnly, disabledDates, yearsOrder }) => (
     <Calendar
       value={value}
       minDate={minDate}
@@ -82,6 +92,7 @@ const meta: Meta<CalendarStoryArgs> = {
       disabled={disabled}
       readOnly={readOnly}
       disabledDates={disabledDates}
+      yearsOrder={yearsOrder}
       onChange={() => {}}
       onMonthChange={() => {}}
     />

--- a/packages/react/components/calendar/Calendar.tsx
+++ b/packages/react/components/calendar/Calendar.tsx
@@ -8,6 +8,7 @@ import { ComponentName } from '../enumsComponentsName'
 import { Icon } from '../icon'
 import { Select, SelectOption } from '../select'
 import { Text } from '../text'
+import { CalendarYearsOrder } from './CalendarEnum'
 import { CalendarProps, ChangeEventCalendar } from './CalendarProps'
 
 const days = [
@@ -36,6 +37,7 @@ function checkIsRange(date: ChangeEventCalendar): date is [Date, Date] | [Date] 
  * @param disabledDates {Date[]} List of disabled/unavailable dates
  * @param onChange {Function} Callback when selected date(s) change
  * @param onMonthChange {Function} Callback when the displayed month changes
+ * @param yearsOrder {CalendarYearsOrder} Order of years in the year selector (asc by default, desc from most recent to oldest)
  * @param testId {string} Test Id for Test Integration
  * - -------------------------- WEB PROPERTIES -------------------------------
  * @param className {string} Additional CSS Classes
@@ -52,6 +54,7 @@ const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
       testId,
       onChange,
       onMonthChange,
+      yearsOrder = CalendarYearsOrder.ASC,
     },
     ref,
   ) => {
@@ -123,8 +126,9 @@ const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
       const maxYear = maxDate.getFullYear()
       const currentYear = value instanceof Date && value?.getFullYear()
       const isCurrentYearInclude = currentYear && currentYear >= minYear && currentYear <= maxYear
+      const isDesc = yearsOrder === CalendarYearsOrder.DESC
       let years = Array.from({ length: maxYear - minYear + 1 }, (_, i) => {
-        const year = minYear + i
+        const year = isDesc ? maxYear - i : minYear + i
         return {
           value: year,
           disabled: false,
@@ -134,7 +138,7 @@ const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
         years = [{ value: currentYear, disabled: true }, ...years]
       }
       return years
-    }, [minDate, maxDate, value])
+    }, [minDate, maxDate, value, yearsOrder])
 
     const availableMonths = React.useMemo(() => {
       const currentYear = visibleMonth.getFullYear()

--- a/packages/react/components/calendar/Calendar.tsx
+++ b/packages/react/components/calendar/Calendar.tsx
@@ -135,7 +135,9 @@ const Calendar = React.forwardRef<HTMLTableElement, CalendarProps>(
         }
       })
       if (currentYear && !isCurrentYearInclude) {
-        years = [{ value: currentYear, disabled: true }, ...years]
+        const currentYearEntry = { value: currentYear, disabled: true }
+        const shouldPrepend = isDesc ? currentYear > maxYear : currentYear < minYear
+        years = shouldPrepend ? [currentYearEntry, ...years] : [...years, currentYearEntry]
       }
       return years
     }, [minDate, maxDate, value, yearsOrder])

--- a/packages/react/components/calendar/CalendarEnum.ts
+++ b/packages/react/components/calendar/CalendarEnum.ts
@@ -1,0 +1,5 @@
+export enum CalendarYearsOrder {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+export type CalendarYearsOrderValues = `${CalendarYearsOrder}`

--- a/packages/react/components/calendar/CalendarProps.ts
+++ b/packages/react/components/calendar/CalendarProps.ts
@@ -1,4 +1,5 @@
 import { Dev } from "@/objects/facets/Dev"
+import { CalendarYearsOrder, CalendarYearsOrderValues } from './CalendarEnum'
 
 export type ChangeEventCalendar = Date | [Date, Date] | [Date] | []
 
@@ -11,4 +12,5 @@ export interface CalendarProps extends Dev {
   onChange?: (e: ChangeEventCalendar) => void
   onMonthChange?: (e: Date) => void
   disabledDates?: Date[]
+  yearsOrder?: CalendarYearsOrder | CalendarYearsOrderValues
 }

--- a/packages/react/components/calendar/index.ts
+++ b/packages/react/components/calendar/index.ts
@@ -1,5 +1,6 @@
 import Calendar from './Calendar'
 
 export * from './CalendarProps'
+export * from './CalendarEnum'
 
 export { Calendar }

--- a/packages/react/components/datepicker/DatePicker.native.tsx
+++ b/packages/react/components/datepicker/DatePicker.native.tsx
@@ -29,6 +29,7 @@ import { DatePickerProps } from './DatePickerProps'
  * @param status {DatePickerStatus} DatePicker status (SUCCESS | WARNING | ERROR | DEFAULT)
  * @param testId {string} Test Id for Test Integration
  * @param id {string} Custom id attribute
+ * @param yearsOrder {CalendarYearsOrder} Order of years in the calendar year selector (asc by default, desc from most recent to oldest)
  */
 const DatePicker = forwardRef<View, DatePickerProps>(
   (
@@ -46,6 +47,7 @@ const DatePicker = forwardRef<View, DatePickerProps>(
       disabledDates,
       testId,
       name,
+      yearsOrder,
       ...others
     },
     ref,
@@ -413,6 +415,7 @@ const DatePicker = forwardRef<View, DatePickerProps>(
                 disabledDates={disabledDates}
                 onChange={handleCalendarChange}
                 disabled={disabled}
+                yearsOrder={yearsOrder}
               />
             </View>
           </View>

--- a/packages/react/components/datepicker/DatePicker.stories.tsx
+++ b/packages/react/components/datepicker/DatePicker.stories.tsx
@@ -87,7 +87,7 @@ export default meta
 export const Default: StoryObj<DatePickerProps> = {
   args: {
     value: '2026-05-15',
-    minDate: '2026-01-01',
+    minDate: '1970-01-01',
     maxDate: '2026-12-31',
     label: 'Date',
     help: 'Pick a date',

--- a/packages/react/components/datepicker/DatePicker.stories.tsx
+++ b/packages/react/components/datepicker/DatePicker.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { CalendarYearsOrder } from '@/components/calendar/CalendarEnum'
 import type { DatePickerProps } from './DatePickerProps'
 import { DatePicker } from './index'
 
@@ -70,6 +71,12 @@ const meta: Meta<DatePickerProps> = {
       description: 'DatePicker status',
       table: { category: 'Validation' },
     },
+    yearsOrder: {
+      control: 'select',
+      options: [CalendarYearsOrder.ASC, CalendarYearsOrder.DESC],
+      description: 'Order of years in the calendar year selector (asc: oldest to most recent, desc: most recent to oldest)',
+      table: { category: 'Main' },
+    },
     onChange: { table: { disable: true } },
     disabledDates: { table: { disable: true } },
   },
@@ -110,5 +117,14 @@ export const Required: StoryObj<DatePickerProps> = {
   args: {
     ...Default.args,
     required: true,
+  },
+}
+
+export const YearsOrderDesc: StoryObj<DatePickerProps> = {
+  args: {
+    ...Default.args,
+    minDate: '1906-01-01',
+    maxDate: '2026-12-31',
+    yearsOrder: CalendarYearsOrder.DESC,
   },
 }

--- a/packages/react/components/datepicker/DatePicker.tsx
+++ b/packages/react/components/datepicker/DatePicker.tsx
@@ -53,6 +53,7 @@ const getFirstDayFocusable = () => {
  * @param status {DatePickerStatus} DatePicker status (SUCCESS | WARNING | ERROR | DEFAULT)
  * @param testId {string} Test Id for Test Integration
  * @param id {string} Custom id attribute
+ * @param yearsOrder {CalendarYearsOrder} Order of years in the calendar year selector (asc by default, desc from most recent to oldest)
  * - -------------------------- WEB PROPERTIES -------------------------------
  * @param className {string} Additional CSS Classes
  * @param name {string} Name attribute
@@ -75,6 +76,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       id = React.useId(),
       testId,
       name,
+      yearsOrder,
       ...others
     },
     ref,
@@ -365,6 +367,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
           onChange={handleChangeCalendar}
           ref={refCalendar}
           value={calendarValue}
+          yearsOrder={yearsOrder}
           onMonthChange={() => {
             if (isOpenCalendar && refCalendar.current) {
               const calendar = refCalendar.current
@@ -391,6 +394,7 @@ const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       calendarValue,
       isOpenCalendar,
       refsFocusable,
+      yearsOrder,
     ])
 
     useEffect(() => {

--- a/packages/react/components/datepicker/DatePickerProps.ts
+++ b/packages/react/components/datepicker/DatePickerProps.ts
@@ -1,3 +1,4 @@
+import { CalendarYearsOrder, CalendarYearsOrderValues } from '@/components/calendar/CalendarEnum'
 import { CommonProps } from '@/objects/facets/CommonProps'
 import { Dev } from '@/objects/facets/Dev'
 import { DatePickerStatus, DatePickerStatusValues } from './DatePickerEnum'
@@ -22,6 +23,7 @@ export interface DatePickerProps extends Dev, CommonProps {
   disabled?: boolean
   disabledDates?: Date[]
   name?: string
+  yearsOrder?: CalendarYearsOrder | CalendarYearsOrderValues
 }
 
 export interface Segment {


### PR DESCRIPTION
## Summary

- Add a `yearsOrder` prop (`asc` | `desc`) on `Calendar` and `DatePicker` to control the order of years displayed in the year selector.
- Default value is `asc` (unchanged behavior, fully backward compatible).
- Useful for use cases like birth date entry with a wide min/max range (e.g. 16 to 120 years), where scrolling from the oldest year to reach recent ones degrades UX.

Ref: [TRIL-133](https://bouyguestelecom.atlassian.net/browse/TRIL-133)

## Changes

- `components/calendar/CalendarEnum.ts` (new): `CalendarYearsOrder` enum (`ASC` / `DESC`)
- `components/calendar/CalendarProps.ts`: add `yearsOrder` prop
- `components/calendar/index.ts`: export the new enum
- `components/calendar/Calendar.tsx` / `Calendar.native.tsx`: invert the `yearsBetween` computation when `yearsOrder === 'desc'`
- `components/datepicker/DatePickerProps.ts`: add `yearsOrder` prop
- `components/datepicker/DatePicker.tsx` / `DatePicker.native.tsx`: forward `yearsOrder` to `<Calendar>`
- `components/calendar/Calendar.stories.tsx` / `components/datepicker/DatePicker.stories.tsx`: storybook controls for `yearsOrder` (+ `YearsOrderDesc` story on DatePicker)
- `.gitignore`: ignore `.codegraph/`

## Out of scope

On mobile (`Calendar.native.tsx`), the year picker is a `ScrollView` that does not auto-scroll to the currently selected year. This pre-existing limitation is not addressed here and is left for a follow-up ticket if needed.

## Testing

- `npm run check-types`: no new errors introduced (pre-existing unrelated errors on `hero`/`spacer` tests and `iconsPath` remain, confirmed identical on `main`)
- `npm run lint`: pre-existing config issue (ESLint 10 vs legacy `.eslintrc.cjs`), unrelated to this change
- Manually tested in Storybook (`Components/Calendar` and `Components/DatePicker`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable year ordering to Calendar and DatePicker components.
  * Users can display years in ascending or descending order, with ascending order remaining the default.
  * Added Storybook controls and examples for the new year-ordering option.

* **Documentation**
  * Added documentation for configuring year ordering in Calendar and DatePicker components.

* **Chores**
  * Added an ignore rule for CodeGraph metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->