### PR TITLE
fix pagination and stepper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.19.0] - 2026-09-xx
+- Add prop yearsOrder on Calendar
+- Fix pagination 
+- Fix stepper css 
+
 
 ## [4.18.1] - 2026-07-23
 - Add icons

--- a/packages/react/components/pagination/Pagination.tsx
+++ b/packages/react/components/pagination/Pagination.tsx
@@ -52,6 +52,8 @@ const Pagination = React.forwardRef<PaginationRef, PaginationProps>(
     )
 
     const [pages, setPages] = useState(() => getPages(defaultPage).pages)
+    const isFirstPage = currentPage === 1
+    const isLastPage = currentPage === length
 
     useEffect(() => {
       setCurrentPage(defaultPage)
@@ -64,6 +66,10 @@ const Pagination = React.forwardRef<PaginationRef, PaginationProps>(
           className={hashClass(styled, clsx('pagination-previous'))}
           {...(currentPage === 1 ? { 'aria-disabled': true } : {})}
           onClick={(e) => {
+            if (isFirstPage) {
+              e.preventDefault()
+              return
+            }
             const nextPage = currentPage - 1
             const nextPages = getPages(nextPage)
             if (onClick) onClick(Object.assign(e, nextPages, { currentPage: nextPage, length }))
@@ -110,6 +116,10 @@ const Pagination = React.forwardRef<PaginationRef, PaginationProps>(
           className={hashClass(styled, clsx('pagination-next'))}
           {...(currentPage === Math.max(length) ? { 'aria-disabled': true } : {})}
           onClick={(e) => {
+            if (isLastPage) {
+              e.preventDefault()
+              return
+            }
             const nextPage = currentPage + 1
             const nextPages = getPages(nextPage)
             if (onClick) onClick(Object.assign(e, nextPages, { currentPage: nextPage, length }))

--- a/packages/react/components/pagination/test/Pagination.test.tsx
+++ b/packages/react/components/pagination/test/Pagination.test.tsx
@@ -40,4 +40,22 @@ describe('Pagination component', () => {
     // Check if the third page link has the correct href attribute
     expect(getByLabelText('Aller à la page 3').getAttribute('href')).toBe('?page=3')
   })
+
+  it('should not navigate or call onClick when navigating beyond the boundaries', () => {
+    const handleClick = jest.fn()
+    const { container, getByLabelText } = render(
+      <Pagination length={2} onClick={handleClick} href={(page) => `?page=${page}`} />,
+    )
+
+    const previous = container.querySelector('.pagination-previous') as HTMLAnchorElement
+    const next = container.querySelector('.pagination-next') as HTMLAnchorElement
+
+    fireEvent.click(previous)
+    expect(handleClick).not.toHaveBeenCalled()
+
+    fireEvent.click(getByLabelText('Aller à la page 2'))
+    fireEvent.click(next)
+    expect(handleClick).toHaveBeenCalledTimes(1)
+    expect(next).toHaveAttribute('aria-disabled', 'true')
+  })
 })

--- a/packages/styles/framework/src/components/_stepper.scss
+++ b/packages/styles/framework/src/components/_stepper.scss
@@ -4,7 +4,6 @@
   display: flex;
   position: relative;
   justify-content: space-between;
-  min-height: 44px;
   gap: $spacing-4;
 
   @include touch {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for ordering calendar years with the `yearsOrder` prop.

- **Bug Fixes**
  - Prevented pagination from navigating beyond the first or last page.
  - Corrected stepper sizing so its height adapts to its content and spacing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->